### PR TITLE
docs: use absolute paths

### DIFF
--- a/docs/src/content/docs/install/docker.mdx
+++ b/docs/src/content/docs/install/docker.mdx
@@ -19,7 +19,7 @@ managed services like AWS [RDS], [ElastiCache], and [S3].
 To connect Hollo to these services, you need to set the environment
 variables through `docker run` command's [`-e`/`--env` option or
 `--env-file` option][1].  To list the environment variables that Hollo
-supports, see the [*Environment variables*](./env) chapter.
+supports, see the [*Environment variables*](/install/env) chapter.
 
 [GitHub Packages]: https://github.com/dahlia/hollo/pkgs/container/hollo
 [PostgreSQL]: https://hub.docker.com/_/postgres

--- a/docs/src/content/docs/install/manual.mdx
+++ b/docs/src/content/docs/install/manual.mdx
@@ -15,7 +15,7 @@ command line.
   way to deploy Hollo, you can use [Railway] to deploy Hollo with just a few
   clicks.
 
-  [Railway]: ./railway
+  [Railway]: /install/railway
 </Aside>
 
 
@@ -87,7 +87,7 @@ Configuration
 Once you've installed Hollo, you need to configure it.  Open the *.env* file
 you created earlier and adjust the environment variables.
 
-See the [*Environment variables*](./env) chapter for details on how to configure
+See the [*Environment variables*](/install/env) chapter for details on how to configure
 Hollo.
 
 

--- a/docs/src/content/docs/install/railway.mdx
+++ b/docs/src/content/docs/install/railway.mdx
@@ -20,7 +20,7 @@ including AWS S3, Cloudflare R2, MinIO, DigitalOcean Spaces, and Linode Object
 Storage.  Once you have your object storage ready, you'll need to configure
 the environment variables appropriately (see how to use the S3 client API
 for each service).  For more information, see the
-[*Environmnet variables*](./env) chapter.
+[*Environmnet variables*](/install/env) chapter.
 
 Once you've set up your environment variables and Hollo is deployed on Railway,
 go to https://yourdomain/setup to set up your login credentials and add your

--- a/docs/src/content/docs/ja/install/docker.mdx
+++ b/docs/src/content/docs/ja/install/docker.mdx
@@ -17,7 +17,7 @@ Holloを実行するには、PostgreSQLのデータベースとメディアを�
 Holloにこれらのサービスを組み合わせるには、
 `docker run`コマンドの[`-e`/`--env`オプションまたは`--env-file`オプション][1]を使用して
 環境変数を設定する必要があります。
-Holloがサポートする環境変数のリストは[**環境変数**](./env)章で確認できます。
+Holloがサポートする環境変数のリストは[**環境変数**](/ja/install/env)章で確認できます。
 
 [GitHub Packages]: https://github.com/dahlia/hollo/pkgs/container/hollo
 [PostgreSQL]: https://hub.docker.com/_/postgres

--- a/docs/src/content/docs/ja/install/manual.mdx
+++ b/docs/src/content/docs/ja/install/manual.mdx
@@ -14,7 +14,7 @@ Holloは手動でインストールすることもできます。
   Holloをもっと自動化された方法でデプロイしたい場合、[Railway]を使えば、
   数回のクリックでHolloをデプロイすることができます。
 
-  [Railway]: ./railway
+  [Railway]: /ja/install/railway
 </Aside>
 
 
@@ -85,7 +85,7 @@ import { Steps } from "@astrojs/starlight/components";
 Holloをインストールしたら、設定を行う必要があります。
 先に作った*.env*ファイルを開いて環境変数の値を適切に変更してください。
 
-[**環境変数**](./env)の章でより詳しい内容を確認することができます。
+[**環境変数**](/ja/install/env)の章でより詳しい内容を確認することができます。
 
 
 サーバー起動

--- a/docs/src/content/docs/ja/install/railway.mdx
+++ b/docs/src/content/docs/ja/install/railway.mdx
@@ -18,7 +18,7 @@ S3互換のオブジェクトストレージには、AWS S3、Cloudflare R2、Mi
 Spaces、Linode Object Storageなどがあります。
 オブジェクトストレージの準備ができたら、環境変数を適切に設定する必要があります。
 （各サービスのS3クライアントAPIの使い方を参照してください）
-詳しくは[**環境変数**](./env)の章を参照してください。
+詳しくは[**環境変数**](/ja/install/env)の章を参照してください。
 
 環境変数を設定し、HolloがRailwayにデプロイされたら、
 https://yourdomain/setup

--- a/docs/src/content/docs/ko/install/docker.mdx
+++ b/docs/src/content/docs/ko/install/docker.mdx
@@ -18,7 +18,7 @@ PostgreSQL 데이터베이스와 미디어 저장을 위한 S3 호환 오브젝�
 Hollo에 해당 서비스들을 연결하려면,
 `docker run` 명령의 [`-e`/`--env` 옵션이나 `--env-file` 옵션][1]을 통해
 환경 변수를 설정해야 합니다.  Hollo가 지원하는 환경 변수 목록은
-[**환경 변수**](./env) 챕터에서 확인할 수 있습니다.
+[**환경 변수**](/ko/install/env) 챕터에서 확인할 수 있습니다.
 
 [GitHub Packages]: https://github.com/dahlia/hollo/pkgs/container/hollo
 [PostgreSQL]: https://hub.docker.com/_/postgres

--- a/docs/src/content/docs/ko/install/manual.mdx
+++ b/docs/src/content/docs/ko/install/manual.mdx
@@ -15,7 +15,7 @@ Hollo는 수동으로도 설치할 수 있습니다.
   방식으로 배포하고 싶다면, [Railway]를 사용하면 몇 번의 클릭만으로 Hollo를
   배포할 수 있습니다.
 
-  [Railway]: ./railway
+  [Railway]: /ko/install/railway
 </Aside>
 
 
@@ -86,7 +86,7 @@ import { Steps } from "@astrojs/starlight/components";
 Hollo가 설치되었다면, 설정을 해야 합니다.
 앞서 만든 *.env* 파일을 열어 환경 변수의 값들을 적절하게 변경해 주세요.
 
-[**환경 변수**](./env) 챕터에서 좀 더 자세한 내용을 확인할 수 있습니다.
+[**환경 변수**](/ko/install/env) 챕터에서 좀 더 자세한 내용을 확인할 수 있습니다.
 
 
 서버 시작하기

--- a/docs/src/content/docs/ko/install/railway.mdx
+++ b/docs/src/content/docs/ko/install/railway.mdx
@@ -19,7 +19,7 @@ S3 호환 오브젝트 스토리지로는 AWS S3, Cloudflare R2, MinIO, DigitalO
 Linode Object Storage 등 여러가지가 있습니다.
 여러분의 오브젝트 스토리지가 준비되었다면, 환경 변수를 적절하게 설정해야 합니다
 (각 서비스의 S3 클라이언트 API 사용법을 참조하세요).
-더 자세한 정보는 [**환경 변수**](./env) 챕터를 참조하세요.
+더 자세한 정보는 [**환경 변수**](/ko/install/env) 챕터를 참조하세요.
 
 환경 변수를 설정하고 Hollo가 Railway에 배포되었다면,
 https://yourdomain/setup (yourdomain은 여러분의 도메인으로 치환)

--- a/docs/src/content/docs/zh-cn/install/docker.mdx
+++ b/docs/src/content/docs/zh-cn/install/docker.mdx
@@ -11,7 +11,7 @@ docker pull ghcr.io/dahlia/hollo:latest
 
 要运行 Hollo，您需要设置一个 PostgreSQL 数据库和一个用于媒体存储的 S3 兼容对象存储。您可以使用 [PostgreSQL] 的官方 Docker 镜像，也可以使用 [MinIO] 作为 S3 兼容对象存储。或者，您也可以使用其他托管服务，如 AWS 的 [RDS]、[ElastiCache] 和 [S3]。
 
-要将 Hollo 连接到这些服务，您需要通过 `docker run` 命令的 [`-e`/`--env` 选项或 `--env-file` 选项][1] 设置环境变量。要查看 Hollo 支持的环境变量，请参阅 [**环境变量**](./env) 章节。
+要将 Hollo 连接到这些服务，您需要通过 `docker run` 命令的 [`-e`/`--env` 选项或 `--env-file` 选项][1] 设置环境变量。要查看 Hollo 支持的环境变量，请参阅 [**环境变量**](/zh-cn/install/env) 章节。
 
 [GitHub Packages]: https://github.com/dahlia/hollo/pkgs/container/hollo
 [PostgreSQL]: https://hub.docker.com/_/postgres

--- a/docs/src/content/docs/zh-cn/install/manual.mdx
+++ b/docs/src/content/docs/zh-cn/install/manual.mdx
@@ -10,7 +10,7 @@ Hollo 可以手动安装在您的服务器上。本指南将引导您完成在�
 <Aside type="tip">
   如果您对类 Unix 系统不熟悉或更喜欢自动化的方式部署 Hollo，可以使用 [Railway] 仅需几次点击即可部署 Hollo。
 
-  [Railway]: ./railway
+  [Railway]: /zh-cn/install/railway
 </Aside>
 
 
@@ -79,7 +79,7 @@ import { Steps } from "@astrojs/starlight/components";
 
 安装 Hollo 后，您需要进行配置。打开之前创建的 *.env* 文件并调整环境变量。
 
-有关如何配置 Hollo 的详细信息，请参阅 [**环境变量**](./env) 章节。
+有关如何配置 Hollo 的详细信息，请参阅 [**环境变量**](/zh-cn/install/env) 章节。
 
 
 启动服务端

--- a/docs/src/content/docs/zh-cn/install/railway.mdx
+++ b/docs/src/content/docs/zh-cn/install/railway.mdx
@@ -11,7 +11,7 @@ import { Aside } from "@astrojs/starlight/components";
 
 点击上方按钮即可在 Railway 上部署 Hollo。通过这个模板，您只需几次点击即可开始使用自己的 Hollo。
 
-要部署 Hollo，您需要 S3 或兼容 S3 的对象存储来存储媒体文件，如图片。目前有许多兼容 S3 的对象存储服务，包括 AWS S3、Cloudflare R2、MinIO、DigitalOcean Spaces 和 Linode Object Storage。准备好对象存储后，您需要适当地配置环境变量（请参阅各服务的 S3 客户端 API 使用方法）。更多信息请参见[**环境变量**](./env)章节。
+要部署 Hollo，您需要 S3 或兼容 S3 的对象存储来存储媒体文件，如图片。目前有许多兼容 S3 的对象存储服务，包括 AWS S3、Cloudflare R2、MinIO、DigitalOcean Spaces 和 Linode Object Storage。准备好对象存储后，您需要适当地配置环境变量（请参阅各服务的 S3 客户端 API 使用方法）。更多信息请参见[**环境变量**](/zh-cn/install/env)章节。
 
 设置好环境变量并在 Railway 上部署了 Hollo之后，请访问 https://yourdomain/setup 来设置您的登录凭据并添加您的个人资料。
 


### PR DESCRIPTION
https://docs.hollo.social has a trailing slash as opposed to local preview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated installation documentation for Hollo to improve clarity and navigability.
	- Changed links from relative paths to absolute paths for better accessibility across all installation guides.
	- Enhanced accuracy in the "Railway" and "Environment variables" sections in multiple language documents (English, Japanese, Korean, Chinese).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->