### PR TITLE
Improve alignment on Mastodon API changes - OAuth / Apps

### DIFF
--- a/src/api/v1/apps.ts
+++ b/src/api/v1/apps.ts
@@ -109,6 +109,7 @@ app.post("/", async (c) => {
     redirect_uri: app.redirectUris.join(" "),
     client_id: app.clientId,
     client_secret: app.clientSecret,
+    // vapid_key is deprecated, it should be fetched from /api/v1/instance instead
     vapid_key: "",
   };
   logger.debug("Created application: {app}", { app: result });

--- a/src/api/v2/instance.ts
+++ b/src/api/v2/instance.ts
@@ -80,6 +80,10 @@ app.get("/", async (c) => {
       translation: {
         enabled: false,
       },
+      // TODO: webpush
+      vapid: {
+        public_key: "",
+      },
     },
     registrations: {
       enabled: false,


### PR DESCRIPTION
- `GET /api/v1/apps/verify_credentials` no longer requires read scope, just a valid access token (or client credential)
- `POST /api/v1/apps` now supports multiple redirect URIs
- `redirect_uri` is deprecated, but software may still rely on it until they switch to `redirect_uris`
- expose `redirect_uri`, `redirect_uris` and `scopes` to verify credentials for Apps.