### PR TITLE
Feat: OAuth authorization server metadata

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,9 +22,13 @@ To be released.
      -  Expose `redirect_uri`, `redirect_uris`, and `scopes` to verify
         credentials for apps.
 
+ -  Added support for RFC 8414 for OAuth Authorization Server metadata endpoint.
+    [[#47] by Emelia Smith]
+
 [#38]: https://github.com/dahlia/hollo/issues/38
 [#41]: https://github.com/dahlia/hollo/pull/41
 [#43]: https://github.com/dahlia/hollo/pull/43
+[#47]: https://github.com/dahlia/hollo/pull/47
 
 
 Version 0.1.0

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,7 @@ import { behindProxy } from "x-forwarded-fetch";
 import api from "./api";
 import fedi from "./federation";
 import image from "./image";
-import oauth from "./oauth";
+import oauth, { oauthAuthorizationServer } from "./oauth";
 import pages from "./pages";
 const app = new Hono();
 
@@ -13,6 +13,7 @@ app.use(federation(fedi, (_) => undefined));
 
 app.route("/", pages);
 app.route("/oauth", oauth);
+app.get("/.well-known/oauth-authorization-server", oauthAuthorizationServer);
 app.route("/api", api);
 app.route("/image", image);
 app.get("/nodeinfo/2.0", (c) => c.redirect("/nodeinfo/2.1"));

--- a/src/oauth.tsx
+++ b/src/oauth.tsx
@@ -1,7 +1,7 @@
 import { base64 } from "@hexagon/base64";
 import { zValidator } from "@hono/zod-validator";
 import { eq } from "drizzle-orm";
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import { cors } from "hono/cors";
 import { createMiddleware } from "hono/factory";
 import { z } from "zod";
@@ -443,5 +443,27 @@ app.post("/token", cors(), async (c) => {
     created_at: (+tokens[0].created / 1000) | 0,
   });
 });
+
+export async function oauthAuthorizationServer(c: Context) {
+  const url = new URL(c.req.url);
+
+  return c.json({
+    issuer: new URL("/", url).href,
+    authorization_endpoint: new URL("/oauth/authorize", url).href,
+    token_endpoint: new URL("/oauth/token", url).href,
+    // Not yet supported by Hollo:
+    // "revocation_endpoint": "",
+    scopes_supported: scopeEnum.enumValues,
+    response_types_supported: ["code"],
+    response_modes_supported: ["query"],
+    grant_types_supported: ["authorization_code", "client_credentials"],
+    token_endpoint_auth_methods_supported: [
+      "client_secret_post",
+      // Not supported by Hollo:
+      // "client_secret_basic",
+    ],
+    app_registration_endpoint: new URL("/api/v1/apps", url).href,
+  });
+}
 
 export default app;


### PR DESCRIPTION
- Fixes #46 
- Also fixes an issue around `redirect_uri` being required for `client_credentials` grant flow (it's actually not required for that flow)
- Ensures that the `redirect_uri` in the token request at least is present within the registered application — however, if we moved to Access Grants being stored, then we'd check "does this access grant authorize redirecting to this URI?" which is actually the OAuth logic here: if you start an OAuth flow with authorize using redirectUri1 but then try to exchange the code with redirectUri2, it should fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new endpoint for OAuth server discovery at `/.well-known/oauth-authorization-server`.
	- Enhanced OAuth functionality with improved error handling and validation for token requests.
	- Added support for two-factor authentication.
	- Introduced functionality for reporting remote accounts and posts.
	- Improved alignment with Mastodon API changes regarding OAuth and applications.
	- Added support for RFC 8414 for OAuth Authorization Server metadata endpoint.

- **Bug Fixes**
	- Improved error messages for invalid redirect URIs and missing required fields in token requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->