### PR TITLE
Enable setting the port and allowPrivateAddress through environment vars

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,7 +5,7 @@ SECRET_KEY=secret_key  # generate a secret key with `openssl rand -base64 32`
 LOG_LEVEL=info
 LOG_QUERY=false
 BEHIND_PROXY=false
-LISTEN_PORT=3000 # if BEHIND_PROXY=true used as port for the server
+LISTEN_PORT=3000
 # Setting ALLOW_PRIVATE_ADDRESS to true disables SSRF (Server-Side Request Forgery) protection
 # Set to true to test in local network
 # Will be replaced by list of allowed IPs once https://github.com/dahlia/fedify/issues/157

--- a/.env.sample
+++ b/.env.sample
@@ -5,6 +5,12 @@ SECRET_KEY=secret_key  # generate a secret key with `openssl rand -base64 32`
 LOG_LEVEL=info
 LOG_QUERY=false
 BEHIND_PROXY=false
+LISTEN_PORT=3000 # if BEHIND_PROXY=true used as port for the server
+# Setting ALLOW_PRIVATE_ADDRESS to true disables SSRF (Server-Side Request Forgery) protection
+# Set to true to test in local network
+# Will be replaced by list of allowed IPs once https://github.com/dahlia/fedify/issues/157
+# is implemented.
+ALLOW_PRIVATE_ADDRESS=false
 REMOTE_ACTOR_FETCH_POSTS=10
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,10 +29,14 @@ To be released.
 
  -  Added a favicon.
 
+ -  Added `LISTEN_PORT` and `ALLOW_PRIVATE_ADDRESS` environment variables.
+    [[#53] by Helge Krueger]
+
 [#38]: https://github.com/dahlia/hollo/issues/38
 [#41]: https://github.com/dahlia/hollo/pull/41
 [#43]: https://github.com/dahlia/hollo/pull/43
 [#47]: https://github.com/dahlia/hollo/pull/47
+[#53]: https://github.com/dahlia/hollo/pull/53
 
 
 Version 0.1.6

--- a/docs/src/content/docs/install/env.mdx
+++ b/docs/src/content/docs/install/env.mdx
@@ -9,6 +9,10 @@ Hollo is configured using environment variables.  You can set them in an *.env*
 file in the root directory of the project, or you can set them using Docker's
 `-e`/`--env` option or Railway's environment variables.
 
+### `LISTEN_PORT` <Badge text="Optional" /> <Badge text="Unused in Railway" variant="tip" />
+
+The port number to listen on.  3000 by default.
+
 ### `DATABASE_URL` <Badge text="Unused in Railway" variant="tip" />
 
 The URL of the PostgreSQL database, e.g.,
@@ -65,6 +69,19 @@ Turned off by default.
   With this option, Hollo will trust the `X-Forwarded-For`, `X-Forwarded-Proto`,
   and `X-Forwarded-Host` headers from the reverse proxy.  This is important for
   security reasons.
+</Aside>
+
+### `ALLOW_PRIVATE_ADDRESS` <Badge text="Optional" />
+
+Setting this to `true` disables SSRF (Server-Side Request Forgery) protection.
+
+Turn on to test in local network.
+
+Turned off by default.
+
+<Aside>
+  Turning on this option is dangerous security-wise.  Only use this option in
+  a trusted environment and never in production.
 </Aside>
 
 ### `S3_REGION` <Badge text="Optional" />

--- a/docs/src/content/docs/ja/install/env.mdx
+++ b/docs/src/content/docs/ja/install/env.mdx
@@ -10,6 +10,10 @@ Holloは環境変数を使って設定を行います。
 Dockerの`-e`/`--env`オプションを使うか、
 Railwayのenvironment variablesメニューから設定できます。
 
+### `LISTEN_PORT` <Badge text="オプション" /> <Badge text="Railwayでは使われない" variant="tip" />
+
+サーバーが受信するポート番号。デフォルトは3000です。
+
 ### `DATABASE_URL` <Badge text="Railwayでは使われない" variant="tip" />
 
 PostgreSQLのデータベースのURL。例：`postgresql://hollo:password@localhost/hollo`
@@ -65,6 +69,19 @@ HolloがL7ロードバランサーの後ろにある場合（通常はそうす�
   このオプションをオンにすると、
   Holloはリバースプロキシから受け取った`X-Forwarded-For`、`X-Forwarded-Proto`、`X-Forwarded-Host`ヘッダを信頼します。
   この動作はセキュリティ上注意が必要です。
+</Aside>
+
+### `ALLOW_PRIVATE_ADDRESS` <Badge text="オプション" />
+
+このオプションを`true`に設定すると、サーバーサイドリクエストフォージェリ（SSRF）攻撃の防止を解除します。
+
+ローカルネットワークでテストする場合は、このオプションをオンにする必要がある場合があります。
+
+デフォルトではオフになっています。
+
+<Aside>
+  このオプションをオンにすることはセキュリティ上危険です。
+  信頼できる環境でのみ使用し、本番環境では使用しないでください。
 </Aside>
 
 ### `S3_REGION` <Badge text="オプション" />

--- a/docs/src/content/docs/ko/install/env.mdx
+++ b/docs/src/content/docs/ko/install/env.mdx
@@ -10,6 +10,10 @@ Hollo는 환경 변수를 통해 여러 가지 설정을 할 수 있습니다.
 Docker의 `-e`/`--env` 옵션을 쓰거나,
 Railway의 environment variables 메뉴에서 설정할 수 있습니다.
 
+### `LISTEN_PORT` <Badge text="선택" /> <Badge text="Railway에서는 안 쓰임" variant="tip" />
+
+서버가 수신할 포트 번호. 기본값은 3000입니다.
+
 ### `DATABASE_URL` <Badge text="Railway에서는 안 쓰임" variant="tip" />
 
 PostgreSQL 데이터베이스의 URL. 예: `postgresql://hollo:password@localhost/hollo`.
@@ -64,6 +68,19 @@ Hollo가 L7 로드 밸런서 뒤에 위치할 경우 (일반적으로 그래야 
   이 옵션을 켜면, Hollo는 리버스 프록시로부터 전달 받은 `X-Forwarded-For`,
   `X-Forwarded-Proto`, `X-Forwarded-Host` 헤더를 신뢰합니다.
   이 동작은 보안상 주의를 기울여야 합니다.
+</Aside>
+
+### `ALLOW_PRIVATE_ADDRESS` <Badge text="선택" />
+
+이 옵션을 `true`로 설정하면 서버 측 요청 위조(SSRF) 공격 방지를 풉니다.
+
+로컬 네트워크에서 테스트할 때 이 옵션을 켜야 할 수 있습니다.
+
+기본적으로는 꺼져 있습니다.
+
+<Aside>
+  이 옵션을 켜는 것은 보안상 위험할 수 있습니다. 신뢰할 수 있는 환경에서만 사용하고,
+  프로덕션 환경에서는 사용하지 마세요.
 </Aside>
 
 ### `S3_REGION` <Badge text="선택" />

--- a/docs/src/content/docs/zh-cn/install/env.mdx
+++ b/docs/src/content/docs/zh-cn/install/env.mdx
@@ -7,6 +7,10 @@ import { Aside, Badge } from '@astrojs/starlight/components';
 
 Hollo是通过环境变量进行配置的。你可以在项目根目录的 *.env* 文件中设置它们，或者使用Docker的`-e`/`--env`选项或Railway的环境变量进行设置。
 
+### `LISTEN_PORT` <Badge text="可选" /> <Badge text="Railway中未使用" variant="tip" />
+
+服务器监听的端口号。默认为3000。
+
 ### `DATABASE_URL` <Badge text="Railway中未使用" variant="tip" />
 
 PostgreSQL数据库的URL，例如：`postgresql://hollo:password@localhost/hollo`。
@@ -55,6 +59,19 @@ openssl rand -hex 32
 
 <Aside>
   启用此选项后，Hollo将信任来自反向代理的`X-Forwarded-For`、`X-Forwarded-Proto`和`X-Forwarded-Host`头。这对于安全来说非常重要。
+</Aside>
+
+### `ALLOW_PRIVATE_ADDRESS` <Badge text="可选" />
+
+将此选项设置为`true`将禁用 SSRF（服务器端请求伪造）保护。
+
+打开此选项可在本地网络中进行测试。
+
+默认情况下关闭。
+
+<Aside>
+  启用此选项存在严重的安全隐患。
+  仅在受信任的环境下使用此选项，切勿在生产环境中使用。
 </Aside>
 
 ### `S3_REGION` <Badge text="可选" />

--- a/src/federation/index.ts
+++ b/src/federation/index.ts
@@ -110,6 +110,8 @@ if (getRedisUrl() == null) {
 export const federation = createFederation<void>({
   kv,
   queue,
+  // biome-ignore lint/complexity/useLiteralKeys: tsc complains about this (TS4111)
+  allowPrivateAddress: process.env["ALLOW_PRIVATE_ADDRESS"] === "true",
 });
 
 federation

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,5 +31,9 @@ app.get("/favicon.png", async (c) => {
 
 // biome-ignore lint/complexity/useLiteralKeys: tsc complains about this (TS4111)
 const BEHIND_PROXY = process.env["BEHIND_PROXY"] === "true";
+// biome-ignore lint/complexity/useLiteralKeys: tsc complains about this (TS4111)
+const HOLLO_PORT = Number.parseInt(process.env["LISTEN_PORT"] ?? "3000", 10);
 
-export default BEHIND_PROXY ? { fetch: behindProxy(app.fetch.bind(app)) } : app;
+export default BEHIND_PROXY
+  ? { fetch: behindProxy(app.fetch.bind(app)), port: HOLLO_PORT }
+  : app;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,8 +32,9 @@ app.get("/favicon.png", async (c) => {
 // biome-ignore lint/complexity/useLiteralKeys: tsc complains about this (TS4111)
 const BEHIND_PROXY = process.env["BEHIND_PROXY"] === "true";
 // biome-ignore lint/complexity/useLiteralKeys: tsc complains about this (TS4111)
-const HOLLO_PORT = Number.parseInt(process.env["LISTEN_PORT"] ?? "3000", 10);
+const LISTEN_PORT = Number.parseInt(process.env["LISTEN_PORT"] ?? "3000", 10);
 
-export default BEHIND_PROXY
-  ? { fetch: behindProxy(app.fetch.bind(app)), port: HOLLO_PORT }
-  : app;
+export default {
+  fetch: BEHIND_PROXY ? behindProxy(app.fetch.bind(app)) : app.fetch.bind(app),
+  port: LISTEN_PORT,
+};


### PR DESCRIPTION
By setting

      BEHIND_PROXY: "true"
      HOLLO_PORT: 80
      ALLOW_PRIVATE_ADDRESS: "true"

one allows private addresses and runs on port 80.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option for handling private addresses in the federation.
	- Added a port configuration option to enhance server functionality.

- **Documentation**
	- Updated `.env.sample` to include the new `LISTEN_PORT` and `ALLOW_PRIVATE_ADDRESS` variables for server configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->