### PR TITLE
Allow extra parameters in `POST /oauth/token`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,16 @@ Version 0.6.1
 
 To be released.
 
+ -  Fixed `POST /oauth/token` endpoint rejecting requests with additional
+    parameters not required by RFC 6749 but commonly sent by clients.
+    The endpoint now gracefully ignores extra parameters like `scope` in
+    `authorization_code` requests and `redirect_uri` in `client_credentials`
+    requests instead of returning validation errors.
+    [[#163], [#164] by Hong Minhee]
+
+[#163]: https://github.com/fedify-dev/hollo/issues/163
+[#164]: https://github.com/fedify-dev/hollo/pull/164
+
 
 Version 0.6.0
 -------------

--- a/src/oauth.tsx
+++ b/src/oauth.tsx
@@ -213,7 +213,11 @@ const INVALID_GRANT_ERROR = {
 };
 
 const tokenRequestSchema = z.discriminatedUnion("grant_type", [
-  z.strictObject({
+  // Use z.object() instead of z.strictObject() to allow clients to send
+  // additional parameters like 'redirect_uri' which are commonly sent but not
+  // required by RFC 6749 for client_credentials grant type.
+  // See also <https://github.com/fedify-dev/hollo/issues/163>:
+  z.object({
     grant_type: z.literal("client_credentials"),
     scope: scopesSchema.optional(),
     // client_id and client_secret are present but consumed by the
@@ -221,7 +225,11 @@ const tokenRequestSchema = z.discriminatedUnion("grant_type", [
     client_id: z.string().optional(),
     client_secret: z.string().optional(),
   }),
-  z.strictObject({
+  // Use z.object() instead of z.strictObject() to allow clients to send
+  // additional parameters like 'scope' which are commonly sent but not
+  // required by RFC 6749 for authorization_code grant type.
+  // See also <https://github.com/fedify-dev/hollo/issues/163>:
+  z.object({
     grant_type: z.literal("authorization_code"),
     redirect_uri: z.string().url(),
     code: z.string(),


### PR DESCRIPTION
Accept but ignore additional parameters like `scope` in `authorization_code` and `redirect_uri` in `client_credentials` requests that many clients send despite not being required by RFC 6749.

Fix <https://github.com/fedify-dev/hollo/issues/163>.