### PR TITLE
Add `STORAGE_URL_BASE` config guide for `fs` driver

### DIFF
--- a/docs/src/content/docs/install/env.mdx
+++ b/docs/src/content/docs/install/env.mdx
@@ -164,6 +164,10 @@ See the [FlyDrive docs] for details about the drivers.
 The public URL base of the asset storage, e.g.,
 `https://media.hollo.social`.
 
+When using `DRIVE_DISK=fs`, you should set this to serve local filesystem files
+via web access, typically in the format `https://<host>/assets`, e.g.,
+`https://hollo.example.com/assets`.
+
 <Aside type="caution">
   - HTTPS is required in production environments.
   - Must be publicly accessible for federation to work correctly.

--- a/docs/src/content/docs/ja/install/env.mdx
+++ b/docs/src/content/docs/ja/install/env.mdx
@@ -164,6 +164,11 @@ Holloでアバター、カスタム絵文字、
 
 メディアファイルを提供する公開URLベース。例：`https://media.hollo.social`。
 
+`DRIVE_DISK=fs`を使用する場合、
+ローカルファイルシステムに保存されたファイルをWebアクセス経由で提供するため、
+通常は`https://<ホスト>/assets`の形式で設定する必要があります。
+例：`https://hollo.example.com/assets`。
+
 <Aside type="caution">
   - 実際の運用時にはHTTPSを使用する必要があります。
   - 公開的にアクセス可能でなければ、連合が正しく動作しません。

--- a/docs/src/content/docs/ko/install/env.mdx
+++ b/docs/src/content/docs/ko/install/env.mdx
@@ -162,6 +162,10 @@ Hollo에서 프로필 사진, 커스텀 에모지, 기타 미디어와 같은 �
 
 미디어 파일들을 서빙할 URL의 앞 부분. 예: `https://media.hollo.social`.
 
+`DRIVE_DISK=fs`인 경우, 로컬 파일시스템에 저장된 파일들을 웹에서 접근할 수 있도록 하려면
+`https://<호스트>/assets` 형태로 설정해야 합니다.
+예: `https://hollo.example.com/assets`.
+
 <Aside type="caution">
   - 실제 운영시에는 HTTPS를 사용해야 합니다.
   - 공개적으로 접근 가능해야 연합이 올바르게 작동합니다.

--- a/docs/src/content/docs/zh-cn/install/env.mdx
+++ b/docs/src/content/docs/zh-cn/install/env.mdx
@@ -147,6 +147,9 @@ Sentry项目的DSN，用于发送错误报告和跟踪信息。
 
 资产存储的公共 URL 基础，例如：`https://media.hollo.social`。
 
+当使用 `DRIVE_DISK=fs` 时，您应该设置此项以通过 Web 访问提供本地文件系统文件，
+通常格式为 `https://<主机>/assets`，例如：`https://hollo.example.com/assets`。
+
 <Aside type="caution">
   - 生产环境要求使用 HTTPS。
   - 必须可公开访问，联盟才能正常工作。


### PR DESCRIPTION
Clarify that when using `DRIVE_DISK=fs`, `STORAGE_URL_BASE` should be set to `https://<host>/assets` format to properly serve local filesystem files via web access.