### PR TITLE
Fix follower-only post access in conversation threads

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,17 @@ Version 0.6.4
 
 To be released.
 
+ -  Fixed a regression bug where follower-only posts were returning `404 Not
+    Found` errors when accessed through conversation threads. This was caused
+    by improper OAuth scope checking that only accepted `read:statuses` scope
+    but tokens contain `read` scope:  [[#169], [#172]]
+
+     -  `GET /api/v1/statuses/:id`
+     -  `GET /api/v1/statuses/:id/context`
+
+[#169]: https://github.com/fedify-dev/hollo/issues/169
+[#172]: https://github.com/fedify-dev/hollo/pull/172
+
 
 Version 0.6.3
 -------------

--- a/src/api/v1/statuses.ts
+++ b/src/api/v1/statuses.ts
@@ -13,6 +13,7 @@ import { zValidator } from "@hono/zod-validator";
 import {
   and,
   eq,
+  exists,
   gt,
   inArray,
   isNotNull,
@@ -60,6 +61,7 @@ import {
   blocks,
   bookmarks,
   customEmojis,
+  follows,
   likes,
   media,
   mentions,
@@ -74,6 +76,86 @@ import { formatPostContent } from "../../text";
 import { type Uuid, isUuid, uuid, uuidv7 } from "../../uuid";
 
 const app = new Hono<{ Variables: Variables }>();
+
+/**
+ * Builds visibility conditions for post queries based on viewer's permissions.
+ * For unauthenticated users, only public/unlisted posts are visible.
+ * For authenticated users, includes private posts from accounts they follow.
+ */
+function buildVisibilityConditions(viewerAccountId: Uuid | null | undefined) {
+  if (viewerAccountId == null) {
+    // Unauthenticated: only public and unlisted posts
+    return inArray(posts.visibility, ["public", "unlisted"]);
+  }
+
+  // Authenticated: include private posts based on follower relationships
+  return or(
+    inArray(posts.visibility, ["public", "unlisted", "direct"]),
+    and(
+      eq(posts.visibility, "private"),
+      or(
+        // User's own posts
+        eq(posts.accountId, viewerAccountId),
+        // Posts from accounts the user follows (approved follows only)
+        exists(
+          db
+            .select({ id: follows.followingId })
+            .from(follows)
+            .where(
+              and(
+                eq(follows.followingId, posts.accountId),
+                eq(follows.followerId, viewerAccountId),
+                isNotNull(follows.approved),
+              ),
+            ),
+        ),
+      ),
+    ),
+  );
+}
+
+/**
+ * Builds mute and block conditions for authenticated users.
+ * Returns undefined for unauthenticated users (no mute/block filtering).
+ */
+function buildMuteAndBlockConditions(viewerAccountId: Uuid | null | undefined) {
+  if (viewerAccountId == null) return undefined;
+
+  return and(
+    notInArray(
+      posts.accountId,
+      db
+        .select({ accountId: mutes.mutedAccountId })
+        .from(mutes)
+        .where(
+          and(
+            eq(mutes.accountId, viewerAccountId),
+            or(
+              isNull(mutes.duration),
+              gt(
+                sql`${mutes.created} + ${mutes.duration}`,
+                sql`CURRENT_TIMESTAMP`,
+              ),
+            ),
+          ),
+        ),
+    ),
+    notInArray(
+      posts.accountId,
+      db
+        .select({ accountId: blocks.blockedAccountId })
+        .from(blocks)
+        .where(eq(blocks.accountId, viewerAccountId)),
+    ),
+    notInArray(
+      posts.accountId,
+      db
+        .select({ accountId: blocks.accountId })
+        .from(blocks)
+        .where(eq(blocks.blockedAccountId, viewerAccountId)),
+    ),
+  );
+}
 
 const statusSchema = z.object({
   status: z.string().min(1).optional(),
@@ -379,20 +461,19 @@ app.put(
 
 app.get("/:id", async (c) => {
   const token = await getAccessToken(c);
-  const owner = token?.scopes.includes("read:statuses")
-    ? token?.accountOwner
-    : null;
+  const owner =
+    token?.scopes.includes("read:statuses") || token?.scopes.includes("read")
+      ? token?.accountOwner
+      : null;
   const id = c.req.param("id");
+
   if (!isUuid(id)) return c.json({ error: "Record not found" }, 404);
+
   const post = await db.query.posts.findFirst({
-    where: and(
-      eq(posts.id, id),
-      owner == null
-        ? inArray(posts.visibility, ["public", "unlisted"])
-        : undefined,
-    ),
+    where: and(eq(posts.id, id), buildVisibilityConditions(owner?.id)),
     with: getPostRelations(owner?.id),
   });
+
   if (post == null) return c.json({ error: "Record not found" }, 404);
   return c.json(serializePost(post, owner, c.req.url));
 });
@@ -470,18 +551,15 @@ app.get(
 
 app.get("/:id/context", async (c) => {
   const token = await getAccessToken(c);
-  const owner = token?.scopes.includes("read:statuses")
-    ? token?.accountOwner
-    : null;
+  const owner =
+    token?.scopes.includes("read:statuses") || token?.scopes.includes("read")
+      ? token?.accountOwner
+      : null;
   const id = c.req.param("id");
   if (!isUuid(id)) return c.json({ error: "Record not found" }, 404);
+
   const post = await db.query.posts.findFirst({
-    where: and(
-      eq(posts.id, id),
-      owner == null
-        ? inArray(posts.visibility, ["public", "unlisted"])
-        : undefined,
-    ),
+    where: and(eq(posts.id, id), buildVisibilityConditions(owner?.id)),
     with: getPostRelations(owner?.id),
   });
   if (post == null) return c.json({ error: "Record not found" }, 404);
@@ -491,47 +569,8 @@ app.get("/:id/context", async (c) => {
     p = await db.query.posts.findFirst({
       where: and(
         eq(posts.id, p.replyTargetId),
-        owner == null
-          ? inArray(posts.visibility, ["public", "unlisted"])
-          : undefined,
-        owner == null
-          ? undefined
-          : notInArray(
-              posts.accountId,
-              db
-                .select({ accountId: mutes.mutedAccountId })
-                .from(mutes)
-                .where(
-                  and(
-                    eq(mutes.accountId, owner.id),
-                    or(
-                      isNull(mutes.duration),
-                      gt(
-                        sql`${mutes.created} + ${mutes.duration}`,
-                        sql`CURRENT_TIMESTAMP`,
-                      ),
-                    ),
-                  ),
-                ),
-            ),
-        owner == null
-          ? undefined
-          : notInArray(
-              posts.accountId,
-              db
-                .select({ accountId: blocks.blockedAccountId })
-                .from(blocks)
-                .where(eq(blocks.accountId, owner.id)),
-            ),
-        owner == null
-          ? undefined
-          : notInArray(
-              posts.accountId,
-              db
-                .select({ accountId: blocks.accountId })
-                .from(blocks)
-                .where(eq(blocks.blockedAccountId, owner.id)),
-            ),
+        buildVisibilityConditions(owner?.id),
+        buildMuteAndBlockConditions(owner?.id),
       ),
       with: getPostRelations(owner?.id),
     });
@@ -546,47 +585,8 @@ app.get("/:id/context", async (c) => {
     const replies = await db.query.posts.findMany({
       where: and(
         eq(posts.replyTargetId, p.id),
-        owner == null
-          ? inArray(posts.visibility, ["public", "unlisted"])
-          : undefined,
-        owner == null
-          ? undefined
-          : notInArray(
-              posts.accountId,
-              db
-                .select({ accountId: mutes.mutedAccountId })
-                .from(mutes)
-                .where(
-                  and(
-                    eq(mutes.accountId, owner.id),
-                    or(
-                      isNull(mutes.duration),
-                      gt(
-                        sql`${mutes.created} + ${mutes.duration}`,
-                        sql`CURRENT_TIMESTAMP`,
-                      ),
-                    ),
-                  ),
-                ),
-            ),
-        owner == null
-          ? undefined
-          : notInArray(
-              posts.accountId,
-              db
-                .select({ accountId: blocks.blockedAccountId })
-                .from(blocks)
-                .where(eq(blocks.accountId, owner.id)),
-            ),
-        owner == null
-          ? undefined
-          : notInArray(
-              posts.accountId,
-              db
-                .select({ accountId: blocks.accountId })
-                .from(blocks)
-                .where(eq(blocks.blockedAccountId, owner.id)),
-            ),
+        buildVisibilityConditions(owner?.id),
+        buildMuteAndBlockConditions(owner?.id),
       ),
       with: getPostRelations(owner?.id),
     });


### PR DESCRIPTION
Resolves https://github.com/fedify-dev/hollo/issues/169 where follower-only posts were returning `404 Not Found` errors when accessed in conversation threads. The regression was caused by improper OAuth scope checking that only accepted `read:statuses` scope but tokens contain `read` scope.

Changes:

- Fix OAuth scope validation to accept both `read:statuses` and `read` scopes
- Add `buildVisibilityConditions()` helper for follower relationship checks
- Add `buildMuteAndBlockConditions()` helper for mute/block filtering
- Update both single status and context endpoints