### PR TITLE
fix: Direct messages are leaked on public post pages

### DIFF
--- a/src/pages/profile/profilePost.tsx
+++ b/src/pages/profile/profilePost.tsx
@@ -1,4 +1,4 @@
-import { and, eq, or } from "drizzle-orm";
+import { and, eq, inArray, or } from "drizzle-orm";
 import { Hono } from "hono";
 import { Layout } from "../../components/Layout.tsx";
 import { Post as PostView } from "../../components/Post.tsx";
@@ -66,6 +66,7 @@ profilePost.get<"/:handle{@[^/]+}/:id{[-a-f0-9]+}">(async (c) => {
         },
       },
       replies: {
+        where: inArray(posts.visibility, ["public", "unlisted"]),
         with: {
           account: true,
           media: true,


### PR DESCRIPTION
## Summary

Filter replies with the condition that visibility is `public` or `unlisted`. Now it hides posts with other visibility, such as `direct`.

## Related Issue

- fixes #246  

## Changes

- Filter replies with condition:
  ```typescript
  where: inArray(posts.visibility, ["public", "unlisted"]),
  ```


## Benefits

Now, hide direct messages from replies.
