### PR TITLE
Fix video thumbnail generation by using temp file instead of stdin pipe

### DIFF
--- a/src/media.ts
+++ b/src/media.ts
@@ -103,9 +103,6 @@ export async function makeVideoScreenshot(
         logger.error(
           "Could not build pipes to ffmpeg, can't create a video screenshot",
         );
-        logger.error("ffmpeg output: {stderr}", {
-          stderr: Buffer.concat(stderrChunks).toString(),
-        });
         resolve(defaultScreenshot);
         return;
       }


### PR DESCRIPTION
Ref: #397

## Summary

This PR restores the previous tempfile-based input flow for ffmpeg when generating video thumbnails.

Some video files fail when ffmpeg reads from non-seekable stdin, producing errors like `partial file` and failing thumbnail generation.
