### PR TITLE
Allow partial update of timeline markers

### DIFF
--- a/src/api/v1/markers.ts
+++ b/src/api/v1/markers.ts
@@ -30,7 +30,7 @@ app.post(
   scopeRequired(["write:statuses"]),
   zValidator(
     "json",
-    z.record(
+    z.partialRecord(
       z.enum(["notifications", "home"]),
       z.object({
         last_read_id: z.string(),


### PR DESCRIPTION
Didn't test it but looks correct as it won't touch anything related to unincluded markers.