### PR TITLE
Return actual user preferences instead of hardcoded values

### DIFF
--- a/src/api/v1/index.ts
+++ b/src/api/v1/index.ts
@@ -57,11 +57,17 @@ app.get(
   tokenRequired,
   scopeRequired(["read:accounts"]),
   (c) => {
+    const owner = c.get("token").accountOwner;
+    if (owner == null) {
+      return c.json(
+        { error: "This method requires an authenticated user" },
+        422,
+      );
+    }
     return c.json({
-      // TODO
-      "posting:default:visibility": "public",
-      "posting:default:sensitive": false,
-      "posting:default:language": null,
+      "posting:default:visibility": owner.visibility,
+      "posting:default:sensitive": owner.account.sensitive,
+      "posting:default:language": owner.language,
       "reading:expand:media": "default",
       "reading:expand:spoilers": false,
     });


### PR DESCRIPTION
## Summary

The `GET /api/v1/preferences` endpoint was returning hardcoded default values for all Mastodon preferences, ignoring the user's actual settings stored in the database.

This change reads `posting:default:visibility`, `posting:default:sensitive`, and `posting:default:language` from the authenticated user's account owner and account records instead of returning static defaults.

Fixes #425

## What changed

- Read the authenticated user's `accountOwner` from the request token
- Return `owner.visibility` for `posting:default:visibility`
- Return `owner.account.sensitive` for `posting:default:sensitive`
- Return `owner.language` for `posting:default:language`
- Added null check for unauthenticated requests (consistent with other endpoints)
- `reading:expand:media` and `reading:expand:spoilers` remain as defaults since there are no corresponding database columns yet

## Test plan

- [x] TypeScript type check passes (`tsc`)
- [x] Biome lint passes (`biome check`)
- [ ] Verify `GET /api/v1/preferences` returns actual user settings with a Mastodon client
- [ ] Verify clients like Phanpy correctly pick up the user's configured preferences