### PR TITLE
Security: Missing ownership filter updates all users' followed tags

### DIFF
--- a/src/api/v1/tags.ts
+++ b/src/api/v1/tags.ts
@@ -1,4 +1,4 @@
-import { sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { db } from "../../db";
 import { serializeTag } from "../../entities/tag";
@@ -25,9 +25,12 @@ app.post("/:id/follow", scopeRequired(["write:follows"]), async (c) => {
     return c.json({ error: "This method requires an authenticated user" }, 422);
   }
   const tag = c.req.param("id");
-  await db.update(accountOwners).set({
-    followedTags: sql`array_append(${accountOwners.followedTags}, ${tag})`,
-  });
+  await db
+    .update(accountOwners)
+    .set({
+      followedTags: sql`array_append(${accountOwners.followedTags}, ${tag})`,
+    })
+    .where(eq(accountOwners.id, owner.id));
   return c.json({ ...serializeTag(tag, null, c.req.url), following: true });
 });
 
@@ -37,9 +40,12 @@ app.post("/:id/unfollow", scopeRequired(["write:follows"]), async (c) => {
     return c.json({ error: "This method requires an authenticated user" }, 422);
   }
   const tag = c.req.param("id");
-  await db.update(accountOwners).set({
-    followedTags: sql`array_remove(${accountOwners.followedTags}, ${tag})`,
-  });
+  await db
+    .update(accountOwners)
+    .set({
+      followedTags: sql`array_remove(${accountOwners.followedTags}, ${tag})`,
+    })
+    .where(eq(accountOwners.id, owner.id));
   return c.json({ ...serializeTag(tag, null, c.req.url), following: false });
 });
 


### PR DESCRIPTION
## Summary

Security: Missing ownership filter updates all users' followed tags

## Problem

**Severity**: `High` | **File**: `src/api/v1/tags.ts:L28`

The follow/unfollow handlers update `accountOwners.followedTags` without a `WHERE` clause tied to the authenticated owner. As written, a single authenticated request modifies followed tags for every account owner in the database, causing cross-account data tampering.

## Solution

Restrict updates to the authenticated account owner, e.g. `.where(eq(accountOwners.id, owner.id))`. Also consider de-duplication and idempotency checks when appending tags.

## Changes

- `src/api/v1/tags.ts` (modified)