### PR TITLE
Avoid backfilling remote quote policies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ Version 0.9.0
 To be released.
 
  -  Added [FEP-044f] quote authorization and policy support on top of the
-    Mastodon-compatible quote APIs.  [[#457], [#459]]
+    Mastodon-compatible quote APIs.  [[#457], [#459], [#460]]
 
      -  Added persistent quote states for `pending`, `accepted`, `rejected`,
         `revoked`, and `unauthorized` quotes, plus quote target and
@@ -100,6 +100,7 @@ To be released.
 [#457]: https://github.com/fedify-dev/hollo/pull/457
 [#458]: https://github.com/fedify-dev/hollo/pull/458
 [#459]: https://github.com/fedify-dev/hollo/pull/459
+[#460]: https://github.com/fedify-dev/hollo/pull/460
 
 
 Version 0.8.1

--- a/drizzle/0086_quote_controls.sql
+++ b/drizzle/0086_quote_controls.sql
@@ -13,7 +13,13 @@ CREATE TYPE "public"."quote_approval_policy" AS ENUM(
 ALTER TABLE "posts" ADD COLUMN "quote_target_iri" text;--> statement-breakpoint
 ALTER TABLE "posts" ADD COLUMN "quote_state" "quote_state";--> statement-breakpoint
 ALTER TABLE "posts" ADD COLUMN "quote_authorization_iri" text;--> statement-breakpoint
-ALTER TABLE "posts" ADD COLUMN "quote_approval_policy" "quote_approval_policy" DEFAULT 'public' NOT NULL;--> statement-breakpoint
+-- Add this column as nullable and without an immediate default.  Existing
+-- remote posts did not have quote policy data before this migration, and
+-- defaulting every row to 'public' would make legacy remote posts
+-- indistinguishable from cached FEP-044f public-policy posts.  The following
+-- backfill intentionally touches only local posts, where Hollo owns the quote
+-- policy and can derive it from existing visibility.
+ALTER TABLE "posts" ADD COLUMN "quote_approval_policy" "quote_approval_policy";--> statement-breakpoint
 UPDATE "posts" AS "post"
 SET
   "quote_target_iri" = "target"."iri",
@@ -21,5 +27,15 @@ SET
 FROM "posts" AS "target"
 WHERE "post"."quote_target_id" = "target"."id";--> statement-breakpoint
 UPDATE "posts"
-SET "quote_approval_policy" = 'nobody'
-WHERE "visibility" IN ('private', 'direct');
+SET "quote_approval_policy" = CASE
+  WHEN "posts"."visibility" IN ('private', 'direct')
+    THEN 'nobody'::"quote_approval_policy"
+  ELSE 'public'::"quote_approval_policy"
+END
+FROM "account_owners"
+WHERE "posts"."actor_id" = "account_owners"."id";--> statement-breakpoint
+-- Set the default only after the local backfill.  New local posts keep the
+-- public default, while persisted remote posts can still explicitly store NULL
+-- when no FEP-044f interaction policy was observed.
+ALTER TABLE "posts"
+ALTER COLUMN "quote_approval_policy" SET DEFAULT 'public';

--- a/drizzle/0087_quote_authorization_requirement.sql
+++ b/drizzle/0087_quote_authorization_requirement.sql
@@ -1,13 +1,13 @@
+-- An earlier draft of 0086 added "quote_approval_policy" as
+-- DEFAULT 'public' NOT NULL, then this migration dropped NOT NULL and rewrote
+-- cached remote public rows to NULL.  That was too expensive on large "posts"
+-- tables and still could not distinguish old legacy remote posts from cached
+-- FEP-044f posts that really advertised a public quote policy.
+--
+-- Since 0086 and 0087 are unreleased and will be applied together, 0086 now
+-- creates the final nullable column shape directly, backfills only local posts,
+-- and leaves existing remote rows NULL.  Keep this cheap DROP NOT NULL for
+-- databases that already applied the earlier 0086 draft but not 0087, so they
+-- can still accept NULL for newly persisted legacy remote posts.
 ALTER TABLE "posts"
-ALTER COLUMN "quote_approval_policy" DROP NOT NULL;--> statement-breakpoint
--- Migration 0086 defaulted every existing post to 'public', so cached remote
--- legacy posts and cached remote FEP-044f public posts are indistinguishable
--- here.  Prefer preserving legacy interoperability for old cached remote
--- posts; limited FEP policies such as 'followers' and 'nobody' remain intact.
-UPDATE "posts"
-SET "quote_approval_policy" = NULL
-WHERE "quote_approval_policy" = 'public'
-AND "actor_id" NOT IN (
-  SELECT "id"
-  FROM "account_owners"
-);
+ALTER COLUMN "quote_approval_policy" DROP NOT NULL;


### PR DESCRIPTION

## Summary

This PR updates the unreleased quote-control migrations so existing remote posts are not mass-updated when introducing nullable quote approval policies.

The previous migration sequence first added `quote_approval_policy` as `DEFAULT 'public' NOT NULL`, then used the follow-up migration to drop `NOT NULL` and rewrite cached remote public rows to `NULL`. That worked functionally, but it was expensive on large `posts` tables and could take many minutes in production-like databases.

This PR makes the migration create the final column shape directly: nullable from the start, with only local posts backfilled. Existing remote posts remain `NULL`, which preserves the legacy remote-post behavior added by the previous PR without requiring a table-wide remote-row rewrite.

## Changes

- Update *drizzle/0086_quote_controls.sql* to add `quote_approval_policy` as nullable and without an immediate default.
- Backfill `quote_approval_policy` only for local posts, where Hollo owns the quote policy and can derive it from visibility.
- Set the default to `'public'` only after the local backfill, so new local posts keep the expected default.
- Update *drizzle/0087_quote_authorization_requirement.sql* to keep the cheap `DROP NOT NULL` for databases that already applied the earlier 0086 draft, while removing the expensive remote-row backfill.
- Add migration comments documenting why remote posts are intentionally left `NULL`.

## Why this is needed

On instances with many cached remote posts, the old follow-up migration spent too long rewriting remote rows from `'public'` to `NULL`. That rewrite is unnecessary if the column is nullable from the beginning.

It also avoids encoding misleading data: before this feature, cached remote posts did not have stored [FEP-044f] quote policy information, so defaulting every old remote row to `'public'` made legacy remote posts indistinguishable from remote posts that truly advertised a public FEP-044f quote policy.

By leaving existing remote rows `NULL`, the database accurately represents “no quote policy was observed,” and the application can treat those posts as legacy quote targets.

[FEP-044f]: https://w3id.org/fep/044f

## Testing

- `pnpm migrate:generate`
- `pnpm run migrate:test`
- `pnpm check`
- `git diff --check`