### PR TITLE
Public reaction list pages for each post

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -235,6 +235,17 @@ To be released.
         are removed; UnoCSS emits a single _src/public/uno.css_ whose
         URL is cache-busted by file mtime.
 
+ -  Added public reaction list pages anchored to each local post:
+    `/@:handle/:id/likes` lists the accounts that liked the post,
+    `/@:handle/:id/shares` lists the accounts that boosted it,
+    `/@:handle/:id/reactions/:emoji` lists the accounts that reacted with
+    a specific emoji, and `/@:handle/:id/quotes` lists the posts that
+    quote it.  Each page features the original post above the list.  On
+    the profile feed and post permalink page, the per-post like, share,
+    quote, and reaction-emoji indicators now link into these pages for
+    local posts; remote posts continue to display the counts as plain
+    text.
+
  -  Added avatar and header image upload to the admin account creation and
     editing forms, with drag-and-drop support and in-page image preview.
     Files are stored using the same storage backend as the Mastodon-compatible

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -244,7 +244,7 @@ To be released.
     the profile feed and post permalink page, the per-post like, share,
     quote, and reaction-emoji indicators now link into these pages for
     local posts; remote posts continue to display the counts as plain
-    text.
+    text.  [[#490]]
 
  -  Added avatar and header image upload to the admin account creation and
     editing forms, with drag-and-drop support and in-page image preview.
@@ -382,6 +382,7 @@ To be released.
 [#487]: https://github.com/fedify-dev/hollo/pull/487
 [#488]: https://github.com/fedify-dev/hollo/issues/488
 [#489]: https://github.com/fedify-dev/hollo/issues/489
+[#490]: https://github.com/fedify-dev/hollo/pull/490
 
 
 Version 0.8.4

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -14,41 +14,43 @@ import type {
 
 export type PostAccount = Account & { owner?: AccountOwner | null };
 
+export type PostForView = DbPost & {
+  account: PostAccount;
+  media: DbMedium[];
+  poll: (DbPoll & { options: PollOption[] }) | null;
+  sharing:
+    | (DbPost & {
+        account: PostAccount;
+        media: DbMedium[];
+        poll: (DbPoll & { options: PollOption[] }) | null;
+        replyTarget: (DbPost & { account: PostAccount }) | null;
+        quoteTarget:
+          | (DbPost & {
+              account: PostAccount;
+              media: DbMedium[];
+              poll: (DbPoll & { options: PollOption[] }) | null;
+              replyTarget: (DbPost & { account: PostAccount }) | null;
+              reactions: Reaction[];
+            })
+          | null;
+        reactions: Reaction[];
+      })
+    | null;
+  replyTarget: (DbPost & { account: PostAccount }) | null;
+  quoteTarget:
+    | (DbPost & {
+        account: PostAccount;
+        media: DbMedium[];
+        poll: (DbPoll & { options: PollOption[] }) | null;
+        replyTarget: (DbPost & { account: PostAccount }) | null;
+        reactions: Reaction[];
+      })
+    | null;
+  reactions: Reaction[];
+};
+
 export interface PostProps {
-  readonly post: DbPost & {
-    account: PostAccount;
-    media: DbMedium[];
-    poll: (DbPoll & { options: PollOption[] }) | null;
-    sharing:
-      | (DbPost & {
-          account: PostAccount;
-          media: DbMedium[];
-          poll: (DbPoll & { options: PollOption[] }) | null;
-          replyTarget: (DbPost & { account: PostAccount }) | null;
-          quoteTarget:
-            | (DbPost & {
-                account: PostAccount;
-                media: DbMedium[];
-                poll: (DbPoll & { options: PollOption[] }) | null;
-                replyTarget: (DbPost & { account: PostAccount }) | null;
-                reactions: Reaction[];
-              })
-            | null;
-          reactions: Reaction[];
-        })
-      | null;
-    replyTarget: (DbPost & { account: PostAccount }) | null;
-    quoteTarget:
-      | (DbPost & {
-          account: PostAccount;
-          media: DbMedium[];
-          poll: (DbPoll & { options: PollOption[] }) | null;
-          replyTarget: (DbPost & { account: PostAccount }) | null;
-          reactions: Reaction[];
-        })
-      | null;
-    reactions: Reaction[];
-  };
+  readonly post: PostForView;
   readonly shared?: Date;
   readonly pinned?: boolean;
   readonly quoted?: boolean;

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -4,6 +4,7 @@ import { proxyUrl } from "../media-proxy";
 import type { PreviewCard } from "../previewcard";
 import type {
   Account,
+  AccountOwner,
   Medium as DbMedium,
   Poll as DbPoll,
   Post as DbPost,
@@ -11,36 +12,38 @@ import type {
   Reaction,
 } from "../schema";
 
+export type PostAccount = Account & { owner?: AccountOwner | null };
+
 export interface PostProps {
   readonly post: DbPost & {
-    account: Account;
+    account: PostAccount;
     media: DbMedium[];
     poll: (DbPoll & { options: PollOption[] }) | null;
     sharing:
       | (DbPost & {
-          account: Account;
+          account: PostAccount;
           media: DbMedium[];
           poll: (DbPoll & { options: PollOption[] }) | null;
-          replyTarget: (DbPost & { account: Account }) | null;
+          replyTarget: (DbPost & { account: PostAccount }) | null;
           quoteTarget:
             | (DbPost & {
-                account: Account;
+                account: PostAccount;
                 media: DbMedium[];
                 poll: (DbPoll & { options: PollOption[] }) | null;
-                replyTarget: (DbPost & { account: Account }) | null;
+                replyTarget: (DbPost & { account: PostAccount }) | null;
                 reactions: Reaction[];
               })
             | null;
           reactions: Reaction[];
         })
       | null;
-    replyTarget: (DbPost & { account: Account }) | null;
+    replyTarget: (DbPost & { account: PostAccount }) | null;
     quoteTarget:
       | (DbPost & {
-          account: Account;
+          account: PostAccount;
           media: DbMedium[];
           poll: (DbPoll & { options: PollOption[] }) | null;
-          replyTarget: (DbPost & { account: Account }) | null;
+          replyTarget: (DbPost & { account: PostAccount }) | null;
           reactions: Reaction[];
         })
       | null;
@@ -85,6 +88,8 @@ export function Post({
   );
   const authorUrl = account.url ?? account.iri;
   const avatar = proxyUrl(account.avatarUrl, baseUrl);
+  const localPermalink =
+    account.owner == null ? null : `/@${account.owner.handle}/${post.id}`;
   const wrapperClass = quoted
     ? "rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-900/60"
     : featured
@@ -188,19 +193,37 @@ export function Post({
         {post.likesCount != null && post.likesCount > 0 && (
           <>
             <span aria-hidden="true">·</span>
-            <span class="inline-flex items-center gap-1">
-              <span class="i-lucide-heart" aria-hidden="true" />
-              {numberFormatter.format(post.likesCount)}
-            </span>
+            <CountLink
+              localPermalink={localPermalink}
+              path="/likes"
+              icon="i-lucide-heart"
+              count={post.likesCount}
+              label="Liked by"
+            />
           </>
         )}
         {post.sharesCount != null && post.sharesCount > 0 && (
           <>
             <span aria-hidden="true">·</span>
-            <span class="inline-flex items-center gap-1">
-              <span class="i-lucide-repeat-2" aria-hidden="true" />
-              {numberFormatter.format(post.sharesCount)}
-            </span>
+            <CountLink
+              localPermalink={localPermalink}
+              path="/shares"
+              icon="i-lucide-repeat-2"
+              count={post.sharesCount}
+              label="Shared by"
+            />
+          </>
+        )}
+        {post.quotesCount != null && post.quotesCount > 0 && (
+          <>
+            <span aria-hidden="true">·</span>
+            <CountLink
+              localPermalink={localPermalink}
+              path="/quotes"
+              icon="i-lucide-quote"
+              count={post.quotesCount}
+              label="Quoted by"
+            />
           </>
         )}
         {post.reactions.length > 0 && (
@@ -208,23 +231,71 @@ export function Post({
             <span aria-hidden="true">·</span>
             <span class="inline-flex flex-wrap items-center gap-1">
               {Object.entries(groupByEmojis(post.reactions, baseUrl)).map(
-                ([emoji, { src, count }]) =>
-                  src == null ? (
-                    <span title={`${emoji} × ${count}`}>{emoji}</span>
+                ([emoji, { src, count }]) => {
+                  const inner =
+                    src == null ? (
+                      <span>{emoji}</span>
+                    ) : (
+                      <img
+                        src={src}
+                        alt={emoji}
+                        class="inline h-4 align-text-bottom"
+                      />
+                    );
+                  const title = `${emoji} × ${count}`;
+                  return localPermalink == null ? (
+                    <span title={title}>{inner}</span>
                   ) : (
-                    <img
-                      src={src}
-                      alt={emoji}
-                      title={`${emoji} × ${count}`}
-                      class="inline h-4 align-text-bottom"
-                    />
-                  ),
+                    <a
+                      href={`${localPermalink}/reactions/${encodeURIComponent(emoji)}`}
+                      title={title}
+                      class="hover:text-brand-700 dark:hover:text-brand-400"
+                    >
+                      {inner}
+                    </a>
+                  );
+                },
               )}
             </span>
           </>
         )}
       </footer>
     </article>
+  );
+}
+
+interface CountLinkProps {
+  readonly localPermalink: string | null;
+  readonly path: string;
+  readonly icon: string;
+  readonly count: number;
+  readonly label: string;
+}
+
+function CountLink({
+  localPermalink,
+  path,
+  icon,
+  count,
+  label,
+}: CountLinkProps) {
+  const inner = (
+    <>
+      <span class={icon} aria-hidden="true" />
+      {numberFormatter.format(count)}
+    </>
+  );
+  if (localPermalink == null) {
+    return <span class="inline-flex items-center gap-1">{inner}</span>;
+  }
+  return (
+    <a
+      href={`${localPermalink}${path}`}
+      title={`${label} ${numberFormatter.format(count)}`}
+      class="inline-flex items-center gap-1 hover:text-brand-700 dark:hover:text-brand-400"
+    >
+      {inner}
+    </a>
   );
 }
 
@@ -255,10 +326,10 @@ interface PostContentProps {
     poll: (DbPoll & { options: PollOption[] }) | null;
     quoteTarget:
       | (DbPost & {
-          account: Account;
+          account: PostAccount;
           media: DbMedium[];
           poll: (DbPoll & { options: PollOption[] }) | null;
-          replyTarget: (DbPost & { account: Account }) | null;
+          replyTarget: (DbPost & { account: PostAccount }) | null;
           reactions: Reaction[];
         })
       | null;

--- a/src/components/PublicAccountList.tsx
+++ b/src/components/PublicAccountList.tsx
@@ -1,0 +1,79 @@
+import { escape } from "es-toolkit";
+
+import { renderCustomEmojis } from "../custom-emoji";
+import { proxyUrl } from "../media-proxy";
+import type { Account } from "../schema";
+import { sanitizeHtml } from "../xss";
+
+export interface PublicAccountListProps {
+  readonly accounts: readonly Account[];
+  readonly baseUrl: URL | string;
+}
+
+export function PublicAccountList({
+  accounts,
+  baseUrl,
+}: PublicAccountListProps) {
+  return (
+    <ul class="mt-4 divide-y divide-neutral-200 dark:divide-neutral-800">
+      {accounts.map((account) => (
+        <li>
+          <PublicAccountItem account={account} baseUrl={baseUrl} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+interface PublicAccountItemProps {
+  readonly account: Account;
+  readonly baseUrl: URL | string;
+}
+
+function PublicAccountItem({ account, baseUrl }: PublicAccountItemProps) {
+  const nameHtml = renderCustomEmojis(
+    escape(account.name),
+    account.emojis,
+    baseUrl,
+  );
+  const bioHtml = renderCustomEmojis(
+    sanitizeHtml(account.bioHtml ?? ""),
+    account.emojis,
+    baseUrl,
+  );
+  const href = account.url ?? account.iri;
+  const avatar = proxyUrl(account.avatarUrl, baseUrl);
+  return (
+    <article class="flex items-start gap-4 py-6">
+      <a href={href} class="shrink-0">
+        {avatar ? (
+          <img
+            src={avatar}
+            alt=""
+            width={48}
+            height={48}
+            class="size-12 rounded-full object-cover"
+          />
+        ) : (
+          <span class="block size-12 rounded-full bg-neutral-200 dark:bg-neutral-800" />
+        )}
+      </a>
+      <div class="min-w-0 flex-1">
+        <a
+          href={href}
+          class="block font-semibold text-neutral-900 hover:underline dark:text-neutral-100"
+          dangerouslySetInnerHTML={{ __html: nameHtml }}
+        />
+        <p class="select-all text-xs text-neutral-500 dark:text-neutral-400">
+          {account.handle}
+        </p>
+        {bioHtml && (
+          <div
+            class="prose prose-sm prose-neutral dark:prose-invert prose-a:text-brand-700 dark:prose-a:text-brand-400 mt-2 max-w-none break-words"
+            dangerouslySetInnerHTML={{ __html: bioHtml }}
+          />
+        )}
+      </div>
+    </article>
+  );
+}

--- a/src/components/PublicAccountList.tsx
+++ b/src/components/PublicAccountList.tsx
@@ -17,7 +17,7 @@ export function PublicAccountList({
   return (
     <ul class="mt-4 divide-y divide-neutral-200 dark:divide-neutral-800">
       {accounts.map((account) => (
-        <li>
+        <li key={account.id}>
           <PublicAccountItem account={account} baseUrl={baseUrl} />
         </li>
       ))}

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -3,7 +3,7 @@ import { Hono } from "hono";
 import xss from "xss";
 
 import { Layout } from "../../components/Layout.tsx";
-import { Post as PostView } from "../../components/Post.tsx";
+import { type PostAccount, Post as PostView } from "../../components/Post.tsx";
 import { Profile } from "../../components/Profile.tsx";
 import { db } from "../../db.ts";
 import {
@@ -18,10 +18,12 @@ import {
   type Reaction,
 } from "../../schema.ts";
 import { isUuid } from "../../uuid.ts";
+import postReactions from "./postReactions.tsx";
 import profilePost from "./profilePost.tsx";
 
 const profile = new Hono();
 
+profile.route("/:id{[-a-f0-9]+}", postReactions);
 profile.route("/:id{[-a-f0-9]+}", profilePost);
 
 const PAGE_SIZE = 30;
@@ -74,34 +76,34 @@ profile.get<"/:handle">(async (c) => {
     limit: PAGE_SIZE,
     offset: (page - 1) * PAGE_SIZE,
     with: {
-      account: true,
+      account: { with: { owner: true } },
       media: true,
       poll: { with: { options: true } },
       sharing: {
         with: {
-          account: true,
+          account: { with: { owner: true } },
           media: true,
           poll: { with: { options: true } },
-          replyTarget: { with: { account: true } },
+          replyTarget: { with: { account: { with: { owner: true } } } },
           quoteTarget: {
             with: {
-              account: true,
+              account: { with: { owner: true } },
               media: true,
               poll: { with: { options: true } },
-              replyTarget: { with: { account: true } },
+              replyTarget: { with: { account: { with: { owner: true } } } },
               reactions: true,
             },
           },
           reactions: true,
         },
       },
-      replyTarget: { with: { account: true } },
+      replyTarget: { with: { account: { with: { owner: true } } } },
       quoteTarget: {
         with: {
-          account: true,
+          account: { with: { owner: true } },
           media: true,
           poll: { with: { options: true } },
-          replyTarget: { with: { account: true } },
+          replyTarget: { with: { account: { with: { owner: true } } } },
           reactions: true,
         },
       },
@@ -116,34 +118,40 @@ profile.get<"/:handle">(async (c) => {
           with: {
             post: {
               with: {
-                account: true,
+                account: { with: { owner: true } },
                 media: true,
                 poll: { with: { options: true } },
                 sharing: {
                   with: {
-                    account: true,
+                    account: { with: { owner: true } },
                     media: true,
                     poll: { with: { options: true } },
-                    replyTarget: { with: { account: true } },
+                    replyTarget: {
+                      with: { account: { with: { owner: true } } },
+                    },
                     quoteTarget: {
                       with: {
-                        account: true,
+                        account: { with: { owner: true } },
                         media: true,
                         poll: { with: { options: true } },
-                        replyTarget: { with: { account: true } },
+                        replyTarget: {
+                          with: { account: { with: { owner: true } } },
+                        },
                         reactions: true,
                       },
                     },
                     reactions: true,
                   },
                 },
-                replyTarget: { with: { account: true } },
+                replyTarget: { with: { account: { with: { owner: true } } } },
                 quoteTarget: {
                   with: {
-                    account: true,
+                    account: { with: { owner: true } },
                     media: true,
                     poll: { with: { options: true } },
-                    replyTarget: { with: { account: true } },
+                    replyTarget: {
+                      with: { account: { with: { owner: true } } },
+                    },
                     reactions: true,
                   },
                 },
@@ -230,34 +238,34 @@ profile.get("/tagged/:tag", async (c) => {
     limit: PAGE_SIZE,
     offset: (page - 1) * PAGE_SIZE,
     with: {
-      account: true,
+      account: { with: { owner: true } },
       media: true,
       poll: { with: { options: true } },
       sharing: {
         with: {
-          account: true,
+          account: { with: { owner: true } },
           media: true,
           poll: { with: { options: true } },
-          replyTarget: { with: { account: true } },
+          replyTarget: { with: { account: { with: { owner: true } } } },
           quoteTarget: {
             with: {
-              account: true,
+              account: { with: { owner: true } },
               media: true,
               poll: { with: { options: true } },
-              replyTarget: { with: { account: true } },
+              replyTarget: { with: { account: { with: { owner: true } } } },
               reactions: true,
             },
           },
           reactions: true,
         },
       },
-      replyTarget: { with: { account: true } },
+      replyTarget: { with: { account: { with: { owner: true } } } },
       quoteTarget: {
         with: {
-          account: true,
+          account: { with: { owner: true } },
           media: true,
           poll: { with: { options: true } },
-          replyTarget: { with: { account: true } },
+          replyTarget: { with: { account: { with: { owner: true } } } },
           reactions: true,
         },
       },
@@ -288,68 +296,68 @@ interface ProfilePageProps {
   readonly accountOwner: AccountOwner & { account: Account };
   readonly tag?: string;
   readonly posts: (Post & {
-    account: Account;
+    account: PostAccount;
     media: Medium[];
     poll: (Poll & { options: PollOption[] }) | null;
     sharing:
       | (Post & {
-          account: Account;
+          account: PostAccount;
           media: Medium[];
           poll: (Poll & { options: PollOption[] }) | null;
-          replyTarget: (Post & { account: Account }) | null;
+          replyTarget: (Post & { account: PostAccount }) | null;
           quoteTarget:
             | (Post & {
-                account: Account;
+                account: PostAccount;
                 media: Medium[];
                 poll: (Poll & { options: PollOption[] }) | null;
-                replyTarget: (Post & { account: Account }) | null;
+                replyTarget: (Post & { account: PostAccount }) | null;
                 reactions: Reaction[];
               })
             | null;
           reactions: Reaction[];
         })
       | null;
-    replyTarget: (Post & { account: Account }) | null;
+    replyTarget: (Post & { account: PostAccount }) | null;
     quoteTarget:
       | (Post & {
-          account: Account;
+          account: PostAccount;
           media: Medium[];
           poll: (Poll & { options: PollOption[] }) | null;
-          replyTarget: (Post & { account: Account }) | null;
+          replyTarget: (Post & { account: PostAccount }) | null;
           reactions: Reaction[];
         })
       | null;
     reactions: Reaction[];
   })[];
   readonly pinnedPosts: (Post & {
-    account: Account;
+    account: PostAccount;
     media: Medium[];
     poll: (Poll & { options: PollOption[] }) | null;
     sharing:
       | (Post & {
-          account: Account;
+          account: PostAccount;
           media: Medium[];
           poll: (Poll & { options: PollOption[] }) | null;
-          replyTarget: (Post & { account: Account }) | null;
+          replyTarget: (Post & { account: PostAccount }) | null;
           quoteTarget:
             | (Post & {
-                account: Account;
+                account: PostAccount;
                 media: Medium[];
                 poll: (Poll & { options: PollOption[] }) | null;
-                replyTarget: (Post & { account: Account }) | null;
+                replyTarget: (Post & { account: PostAccount }) | null;
                 reactions: Reaction[];
               })
             | null;
           reactions: Reaction[];
         })
       | null;
-    replyTarget: (Post & { account: Account }) | null;
+    replyTarget: (Post & { account: PostAccount }) | null;
     quoteTarget:
       | (Post & {
-          account: Account;
+          account: PostAccount;
           media: Medium[];
           poll: (Poll & { options: PollOption[] }) | null;
-          replyTarget: (Post & { account: Account }) | null;
+          replyTarget: (Post & { account: PostAccount }) | null;
           reactions: Reaction[];
         })
       | null;

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -3,19 +3,14 @@ import { Hono } from "hono";
 import xss from "xss";
 
 import { Layout } from "../../components/Layout.tsx";
-import { type PostAccount, Post as PostView } from "../../components/Post.tsx";
+import { type PostForView, Post as PostView } from "../../components/Post.tsx";
 import { Profile } from "../../components/Profile.tsx";
 import { db } from "../../db.ts";
 import {
   type Account,
   type AccountOwner,
   type FeaturedTag,
-  type Medium,
-  type Poll,
-  type PollOption,
-  type Post,
   posts,
-  type Reaction,
 } from "../../schema.ts";
 import { isUuid } from "../../uuid.ts";
 import postReactions from "./postReactions.tsx";
@@ -187,74 +182,8 @@ profile.get("/tagged/:tag", async (c) => {
 interface ProfilePageProps {
   readonly accountOwner: AccountOwner & { account: Account };
   readonly tag?: string;
-  readonly posts: (Post & {
-    account: PostAccount;
-    media: Medium[];
-    poll: (Poll & { options: PollOption[] }) | null;
-    sharing:
-      | (Post & {
-          account: PostAccount;
-          media: Medium[];
-          poll: (Poll & { options: PollOption[] }) | null;
-          replyTarget: (Post & { account: PostAccount }) | null;
-          quoteTarget:
-            | (Post & {
-                account: PostAccount;
-                media: Medium[];
-                poll: (Poll & { options: PollOption[] }) | null;
-                replyTarget: (Post & { account: PostAccount }) | null;
-                reactions: Reaction[];
-              })
-            | null;
-          reactions: Reaction[];
-        })
-      | null;
-    replyTarget: (Post & { account: PostAccount }) | null;
-    quoteTarget:
-      | (Post & {
-          account: PostAccount;
-          media: Medium[];
-          poll: (Poll & { options: PollOption[] }) | null;
-          replyTarget: (Post & { account: PostAccount }) | null;
-          reactions: Reaction[];
-        })
-      | null;
-    reactions: Reaction[];
-  })[];
-  readonly pinnedPosts: (Post & {
-    account: PostAccount;
-    media: Medium[];
-    poll: (Poll & { options: PollOption[] }) | null;
-    sharing:
-      | (Post & {
-          account: PostAccount;
-          media: Medium[];
-          poll: (Poll & { options: PollOption[] }) | null;
-          replyTarget: (Post & { account: PostAccount }) | null;
-          quoteTarget:
-            | (Post & {
-                account: PostAccount;
-                media: Medium[];
-                poll: (Poll & { options: PollOption[] }) | null;
-                replyTarget: (Post & { account: PostAccount }) | null;
-                reactions: Reaction[];
-              })
-            | null;
-          reactions: Reaction[];
-        })
-      | null;
-    replyTarget: (Post & { account: PostAccount }) | null;
-    quoteTarget:
-      | (Post & {
-          account: PostAccount;
-          media: Medium[];
-          poll: (Poll & { options: PollOption[] }) | null;
-          replyTarget: (Post & { account: PostAccount }) | null;
-          reactions: Reaction[];
-        })
-      | null;
-    reactions: Reaction[];
-  })[];
+  readonly posts: PostForView[];
+  readonly pinnedPosts: PostForView[];
   readonly featuredTags: FeaturedTag[];
   readonly atomUrl?: string;
   readonly olderUrl?: string;

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -19,6 +19,7 @@ import {
 } from "../../schema.ts";
 import { isUuid } from "../../uuid.ts";
 import postReactions from "./postReactions.tsx";
+import { postViewRelations } from "./postRelations.ts";
 import profilePost from "./profilePost.tsx";
 
 const profile = new Hono();
@@ -75,90 +76,14 @@ profile.get<"/:handle">(async (c) => {
     orderBy: (posts, { desc }) => [desc(posts.id)],
     limit: PAGE_SIZE,
     offset: (page - 1) * PAGE_SIZE,
-    with: {
-      account: { with: { owner: true } },
-      media: true,
-      poll: { with: { options: true } },
-      sharing: {
-        with: {
-          account: { with: { owner: true } },
-          media: true,
-          poll: { with: { options: true } },
-          replyTarget: { with: { account: { with: { owner: true } } } },
-          quoteTarget: {
-            with: {
-              account: { with: { owner: true } },
-              media: true,
-              poll: { with: { options: true } },
-              replyTarget: { with: { account: { with: { owner: true } } } },
-              reactions: true,
-            },
-          },
-          reactions: true,
-        },
-      },
-      replyTarget: { with: { account: { with: { owner: true } } } },
-      quoteTarget: {
-        with: {
-          account: { with: { owner: true } },
-          media: true,
-          poll: { with: { options: true } },
-          replyTarget: { with: { account: { with: { owner: true } } } },
-          reactions: true,
-        },
-      },
-      reactions: true,
-    },
+    with: postViewRelations,
   });
   const pinnedPostList =
     cont == null
       ? await db.query.pinnedPosts.findMany({
           where: { accountId: { eq: owner.id } },
           orderBy: (pinnedPosts, { desc }) => [desc(pinnedPosts.index)],
-          with: {
-            post: {
-              with: {
-                account: { with: { owner: true } },
-                media: true,
-                poll: { with: { options: true } },
-                sharing: {
-                  with: {
-                    account: { with: { owner: true } },
-                    media: true,
-                    poll: { with: { options: true } },
-                    replyTarget: {
-                      with: { account: { with: { owner: true } } },
-                    },
-                    quoteTarget: {
-                      with: {
-                        account: { with: { owner: true } },
-                        media: true,
-                        poll: { with: { options: true } },
-                        replyTarget: {
-                          with: { account: { with: { owner: true } } },
-                        },
-                        reactions: true,
-                      },
-                    },
-                    reactions: true,
-                  },
-                },
-                replyTarget: { with: { account: { with: { owner: true } } } },
-                quoteTarget: {
-                  with: {
-                    account: { with: { owner: true } },
-                    media: true,
-                    poll: { with: { options: true } },
-                    replyTarget: {
-                      with: { account: { with: { owner: true } } },
-                    },
-                    reactions: true,
-                  },
-                },
-                reactions: true,
-              },
-            },
-          },
+          with: { post: { with: postViewRelations } },
         })
       : [];
   const featuredTagList = await db.query.featuredTags.findMany({
@@ -237,40 +162,7 @@ profile.get("/tagged/:tag", async (c) => {
     orderBy: (posts, { desc }) => [desc(posts.id)],
     limit: PAGE_SIZE,
     offset: (page - 1) * PAGE_SIZE,
-    with: {
-      account: { with: { owner: true } },
-      media: true,
-      poll: { with: { options: true } },
-      sharing: {
-        with: {
-          account: { with: { owner: true } },
-          media: true,
-          poll: { with: { options: true } },
-          replyTarget: { with: { account: { with: { owner: true } } } },
-          quoteTarget: {
-            with: {
-              account: { with: { owner: true } },
-              media: true,
-              poll: { with: { options: true } },
-              replyTarget: { with: { account: { with: { owner: true } } } },
-              reactions: true,
-            },
-          },
-          reactions: true,
-        },
-      },
-      replyTarget: { with: { account: { with: { owner: true } } } },
-      quoteTarget: {
-        with: {
-          account: { with: { owner: true } },
-          media: true,
-          poll: { with: { options: true } },
-          replyTarget: { with: { account: { with: { owner: true } } } },
-          reactions: true,
-        },
-      },
-      reactions: true,
-    },
+    with: postViewRelations,
   });
   const featuredTagList = await db.query.featuredTags.findMany({
     where: { accountOwnerId: { eq: owner.id } },

--- a/src/pages/profile/postReactions.tsx
+++ b/src/pages/profile/postReactions.tsx
@@ -8,6 +8,7 @@ import db from "../../db.ts";
 import { proxyUrl } from "../../media-proxy.ts";
 import { type AccountOwner, likes, posts, reactions } from "../../schema.ts";
 import { isUuid } from "../../uuid.ts";
+import { postViewRelations } from "./postRelations.ts";
 import { summarizePostForTitle } from "./summary.ts";
 
 const PAGE_SIZE = 100;
@@ -36,42 +37,7 @@ async function loadLocalPost(c: Context): Promise<{
           or(eq(posts.visibility, "public"), eq(posts.visibility, "unlisted")),
         )!,
     },
-    with: {
-      account: { with: { owner: true } },
-      media: true,
-      poll: { with: { options: true } },
-      sharing: {
-        with: {
-          account: { with: { owner: true } },
-          media: true,
-          poll: { with: { options: true } },
-          replyTarget: { with: { account: { with: { owner: true } } } },
-          quoteTarget: {
-            with: {
-              account: { with: { owner: true } },
-              media: true,
-              poll: { with: { options: true } },
-              replyTarget: {
-                with: { account: { with: { owner: true } } },
-              },
-              reactions: true,
-            },
-          },
-          reactions: true,
-        },
-      },
-      replyTarget: { with: { account: { with: { owner: true } } } },
-      quoteTarget: {
-        with: {
-          account: { with: { owner: true } },
-          media: true,
-          poll: { with: { options: true } },
-          replyTarget: { with: { account: { with: { owner: true } } } },
-          reactions: true,
-        },
-      },
-      reactions: true,
-    },
+    with: postViewRelations,
   });
   if (post == null) return null;
   return { accountOwner, post };
@@ -300,42 +266,7 @@ postReactions.get("/quotes", async (c) => {
     orderBy: (posts, { desc }) => [desc(posts.id)],
     limit: PAGE_SIZE,
     offset: (page - 1) * PAGE_SIZE,
-    with: {
-      account: { with: { owner: true } },
-      media: true,
-      poll: { with: { options: true } },
-      sharing: {
-        with: {
-          account: { with: { owner: true } },
-          media: true,
-          poll: { with: { options: true } },
-          replyTarget: { with: { account: { with: { owner: true } } } },
-          quoteTarget: {
-            with: {
-              account: { with: { owner: true } },
-              media: true,
-              poll: { with: { options: true } },
-              replyTarget: {
-                with: { account: { with: { owner: true } } },
-              },
-              reactions: true,
-            },
-          },
-          reactions: true,
-        },
-      },
-      replyTarget: { with: { account: { with: { owner: true } } } },
-      quoteTarget: {
-        with: {
-          account: { with: { owner: true } },
-          media: true,
-          poll: { with: { options: true } },
-          replyTarget: { with: { account: { with: { owner: true } } } },
-          reactions: true,
-        },
-      },
-      reactions: true,
-    },
+    with: postViewRelations,
   });
 
   const { newerUrl, olderUrl } = paginationUrls(page, page * PAGE_SIZE < total);

--- a/src/pages/profile/postReactions.tsx
+++ b/src/pages/profile/postReactions.tsx
@@ -222,7 +222,9 @@ postReactions.get("/reactions/:emoji", async (c) => {
   });
 
   const { newerUrl, olderUrl } = paginationUrls(page, page * PAGE_SIZE < total);
-  const customEmojiUrl = rows.find((r) => r.customEmoji != null)?.customEmoji;
+  const customEmojiUrl = post.reactions.find(
+    (r) => r.emoji === emoji && r.customEmoji != null,
+  )?.customEmoji;
   const proxiedEmojiUrl =
     customEmojiUrl == null ? null : proxyUrl(customEmojiUrl, c.req.url);
   const emojiNode =

--- a/src/pages/profile/postReactions.tsx
+++ b/src/pages/profile/postReactions.tsx
@@ -18,6 +18,7 @@ import {
   reactions,
 } from "../../schema.ts";
 import { isUuid } from "../../uuid.ts";
+import { summarizePostForTitle } from "./summary.ts";
 
 const PAGE_SIZE = 100;
 
@@ -424,11 +425,7 @@ function ReactionListPage({
   olderUrl,
   children,
 }: ReactionListPageProps) {
-  const summary =
-    post.summary ??
-    ((post.content ?? "").length > 30
-      ? `${(post.content ?? "").substring(0, 30)}…`
-      : (post.content ?? ""));
+  const summary = summarizePostForTitle(post);
   return (
     <Layout
       title={`${pageTitle}: ${summary} — ${post.account.name}`}

--- a/src/pages/profile/postReactions.tsx
+++ b/src/pages/profile/postReactions.tsx
@@ -285,7 +285,7 @@ postReactions.get("/quotes", async (c) => {
     >
       <div class="mt-2 divide-y divide-neutral-200 dark:divide-neutral-800">
         {quoteRows.map((q) => (
-          <PostView post={q} baseUrl={c.req.url} />
+          <PostView key={q.id} post={q} baseUrl={c.req.url} />
         ))}
       </div>
     </ReactionListPage>,

--- a/src/pages/profile/postReactions.tsx
+++ b/src/pages/profile/postReactions.tsx
@@ -2,21 +2,11 @@ import { and, count, eq, isNull, or } from "drizzle-orm";
 import { type Context, Hono } from "hono";
 
 import { Layout } from "../../components/Layout.tsx";
-import { type PostAccount, Post as PostView } from "../../components/Post.tsx";
+import { type PostForView, Post as PostView } from "../../components/Post.tsx";
 import { PublicAccountList } from "../../components/PublicAccountList.tsx";
 import db from "../../db.ts";
 import { proxyUrl } from "../../media-proxy.ts";
-import {
-  type AccountOwner,
-  likes,
-  type Medium,
-  type Poll,
-  type PollOption,
-  type Post,
-  posts,
-  type Reaction,
-  reactions,
-} from "../../schema.ts";
+import { type AccountOwner, likes, posts, reactions } from "../../schema.ts";
 import { isUuid } from "../../uuid.ts";
 import { summarizePostForTitle } from "./summary.ts";
 
@@ -24,44 +14,9 @@ const PAGE_SIZE = 100;
 
 const postReactions = new Hono();
 
-type FeaturedPost = Post & {
-  account: PostAccount;
-  media: Medium[];
-  poll: (Poll & { options: PollOption[] }) | null;
-  sharing:
-    | (Post & {
-        account: PostAccount;
-        media: Medium[];
-        poll: (Poll & { options: PollOption[] }) | null;
-        replyTarget: (Post & { account: PostAccount }) | null;
-        quoteTarget:
-          | (Post & {
-              account: PostAccount;
-              media: Medium[];
-              poll: (Poll & { options: PollOption[] }) | null;
-              replyTarget: (Post & { account: PostAccount }) | null;
-              reactions: Reaction[];
-            })
-          | null;
-        reactions: Reaction[];
-      })
-    | null;
-  replyTarget: (Post & { account: PostAccount }) | null;
-  quoteTarget:
-    | (Post & {
-        account: PostAccount;
-        media: Medium[];
-        poll: (Poll & { options: PollOption[] }) | null;
-        replyTarget: (Post & { account: PostAccount }) | null;
-        reactions: Reaction[];
-      })
-    | null;
-  reactions: Reaction[];
-};
-
 async function loadLocalPost(c: Context): Promise<{
   accountOwner: AccountOwner;
-  post: FeaturedPost;
+  post: PostForView;
 } | null> {
   let handle = c.req.param("handle");
   const postId = c.req.param("id");
@@ -406,7 +361,7 @@ postReactions.get("/quotes", async (c) => {
 
 interface ReactionListPageProps {
   readonly accountOwner: AccountOwner;
-  readonly post: FeaturedPost;
+  readonly post: PostForView;
   readonly pageTitle: string;
   readonly heading: unknown;
   readonly baseUrl: URL | string;

--- a/src/pages/profile/postReactions.tsx
+++ b/src/pages/profile/postReactions.tsx
@@ -5,6 +5,7 @@ import { Layout } from "../../components/Layout.tsx";
 import { type PostAccount, Post as PostView } from "../../components/Post.tsx";
 import { PublicAccountList } from "../../components/PublicAccountList.tsx";
 import db from "../../db.ts";
+import { proxyUrl } from "../../media-proxy.ts";
 import {
   type AccountOwner,
   likes,
@@ -265,6 +266,24 @@ postReactions.get("/reactions/:emoji", async (c) => {
   });
 
   const { newerUrl, olderUrl } = paginationUrls(page, page * PAGE_SIZE < total);
+  const customEmojiUrl = rows.find((r) => r.customEmoji != null)?.customEmoji;
+  const proxiedEmojiUrl =
+    customEmojiUrl == null ? null : proxyUrl(customEmojiUrl, c.req.url);
+  const emojiNode =
+    proxiedEmojiUrl == null ? (
+      <span>{emoji}</span>
+    ) : (
+      <img
+        src={proxiedEmojiUrl}
+        alt={emoji}
+        title={emoji}
+        class="inline h-4 align-text-bottom"
+      />
+    );
+  const headingPrefix =
+    total === 1
+      ? "1 reaction with "
+      : `${numberFormatter.format(total)} reactions with `;
 
   return c.html(
     <ReactionListPage
@@ -272,9 +291,10 @@ postReactions.get("/reactions/:emoji", async (c) => {
       post={post}
       pageTitle={`Reacted ${emoji} by`}
       heading={
-        total === 1
-          ? `1 reaction with ${emoji}`
-          : `${numberFormatter.format(total)} reactions with ${emoji}`
+        <>
+          {headingPrefix}
+          {emojiNode}
+        </>
       }
       baseUrl={c.req.url}
       newerUrl={newerUrl}
@@ -387,7 +407,7 @@ interface ReactionListPageProps {
   readonly accountOwner: AccountOwner;
   readonly post: FeaturedPost;
   readonly pageTitle: string;
-  readonly heading: string;
+  readonly heading: unknown;
   readonly baseUrl: URL | string;
   readonly newerUrl?: string;
   readonly olderUrl?: string;

--- a/src/pages/profile/postReactions.tsx
+++ b/src/pages/profile/postReactions.tsx
@@ -1,0 +1,459 @@
+import { and, count, eq, isNull, or } from "drizzle-orm";
+import { type Context, Hono } from "hono";
+
+import { Layout } from "../../components/Layout.tsx";
+import { type PostAccount, Post as PostView } from "../../components/Post.tsx";
+import { PublicAccountList } from "../../components/PublicAccountList.tsx";
+import db from "../../db.ts";
+import {
+  type AccountOwner,
+  likes,
+  type Medium,
+  type Poll,
+  type PollOption,
+  type Post,
+  posts,
+  type Reaction,
+  reactions,
+} from "../../schema.ts";
+import { isUuid } from "../../uuid.ts";
+
+const PAGE_SIZE = 100;
+
+const postReactions = new Hono();
+
+type FeaturedPost = Post & {
+  account: PostAccount;
+  media: Medium[];
+  poll: (Poll & { options: PollOption[] }) | null;
+  sharing:
+    | (Post & {
+        account: PostAccount;
+        media: Medium[];
+        poll: (Poll & { options: PollOption[] }) | null;
+        replyTarget: (Post & { account: PostAccount }) | null;
+        quoteTarget:
+          | (Post & {
+              account: PostAccount;
+              media: Medium[];
+              poll: (Poll & { options: PollOption[] }) | null;
+              replyTarget: (Post & { account: PostAccount }) | null;
+              reactions: Reaction[];
+            })
+          | null;
+        reactions: Reaction[];
+      })
+    | null;
+  replyTarget: (Post & { account: PostAccount }) | null;
+  quoteTarget:
+    | (Post & {
+        account: PostAccount;
+        media: Medium[];
+        poll: (Poll & { options: PollOption[] }) | null;
+        replyTarget: (Post & { account: PostAccount }) | null;
+        reactions: Reaction[];
+      })
+    | null;
+  reactions: Reaction[];
+};
+
+async function loadLocalPost(c: Context): Promise<{
+  accountOwner: AccountOwner;
+  post: FeaturedPost;
+} | null> {
+  let handle = c.req.param("handle");
+  const postId = c.req.param("id");
+  if (handle == null || postId == null) return null;
+  if (!isUuid(postId)) return null;
+  if (handle.startsWith("@")) handle = handle.substring(1);
+  const accountOwner = await db.query.accountOwners.findFirst({
+    where: { handle: { eq: handle } },
+  });
+  if (accountOwner == null) return null;
+  const post = await db.query.posts.findFirst({
+    where: {
+      RAW: (posts, { and, eq, or }) =>
+        and(
+          eq(posts.accountId, accountOwner.id),
+          eq(posts.id, postId),
+          or(eq(posts.visibility, "public"), eq(posts.visibility, "unlisted")),
+        )!,
+    },
+    with: {
+      account: { with: { owner: true } },
+      media: true,
+      poll: { with: { options: true } },
+      sharing: {
+        with: {
+          account: { with: { owner: true } },
+          media: true,
+          poll: { with: { options: true } },
+          replyTarget: { with: { account: { with: { owner: true } } } },
+          quoteTarget: {
+            with: {
+              account: { with: { owner: true } },
+              media: true,
+              poll: { with: { options: true } },
+              replyTarget: {
+                with: { account: { with: { owner: true } } },
+              },
+              reactions: true,
+            },
+          },
+          reactions: true,
+        },
+      },
+      replyTarget: { with: { account: { with: { owner: true } } } },
+      quoteTarget: {
+        with: {
+          account: { with: { owner: true } },
+          media: true,
+          poll: { with: { options: true } },
+          replyTarget: { with: { account: { with: { owner: true } } } },
+          reactions: true,
+        },
+      },
+      reactions: true,
+    },
+  });
+  if (post == null) return null;
+  return { accountOwner, post };
+}
+
+function parsePage(c: Context): number | null {
+  const pageStr = c.req.query("page");
+  if (pageStr === undefined) return 1;
+  const parsed = Number.parseInt(pageStr, 10);
+  if (Number.isNaN(parsed) || parsed < 1) return null;
+  return parsed;
+}
+
+function paginationUrls(
+  page: number,
+  hasNext: boolean,
+): { newerUrl?: string; olderUrl?: string } {
+  return {
+    newerUrl: page > 1 ? `?page=${page - 1}` : undefined,
+    olderUrl: hasNext ? `?page=${page + 1}` : undefined,
+  };
+}
+
+const numberFormatter = new Intl.NumberFormat("en-US");
+
+postReactions.get("/likes", async (c) => {
+  const loaded = await loadLocalPost(c);
+  if (loaded == null) return c.notFound();
+  const { accountOwner, post } = loaded;
+  const page = parsePage(c);
+  if (page == null) return c.notFound();
+
+  const [{ total }] = await db
+    .select({ total: count() })
+    .from(likes)
+    .where(eq(likes.postId, post.id));
+  const maxPage = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  if (page > maxPage) return c.notFound();
+
+  const rows = await db.query.likes.findMany({
+    where: { postId: { eq: post.id } },
+    orderBy: (likes, { desc }) => [desc(likes.created)],
+    limit: PAGE_SIZE,
+    offset: (page - 1) * PAGE_SIZE,
+    with: { account: true },
+  });
+
+  const { newerUrl, olderUrl } = paginationUrls(page, page * PAGE_SIZE < total);
+
+  return c.html(
+    <ReactionListPage
+      accountOwner={accountOwner}
+      post={post}
+      pageTitle="Liked by"
+      heading={
+        total === 1 ? "1 like" : `${numberFormatter.format(total)} likes`
+      }
+      baseUrl={c.req.url}
+      newerUrl={newerUrl}
+      olderUrl={olderUrl}
+    >
+      <PublicAccountList
+        accounts={rows.map((r) => r.account)}
+        baseUrl={c.req.url}
+      />
+    </ReactionListPage>,
+  );
+});
+
+postReactions.get("/shares", async (c) => {
+  const loaded = await loadLocalPost(c);
+  if (loaded == null) return c.notFound();
+  const { accountOwner, post } = loaded;
+  const page = parsePage(c);
+  if (page == null) return c.notFound();
+
+  const [{ total }] = await db
+    .select({ total: count() })
+    .from(posts)
+    .where(
+      and(
+        eq(posts.sharingId, post.id),
+        or(eq(posts.visibility, "public"), eq(posts.visibility, "unlisted")),
+      ),
+    );
+  const maxPage = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  if (page > maxPage) return c.notFound();
+
+  const rows = await db.query.posts.findMany({
+    where: {
+      RAW: (posts, { and, eq, or }) =>
+        and(
+          eq(posts.sharingId, post.id),
+          or(eq(posts.visibility, "public"), eq(posts.visibility, "unlisted")),
+        )!,
+    },
+    orderBy: (posts, { desc }) => [desc(posts.id)],
+    limit: PAGE_SIZE,
+    offset: (page - 1) * PAGE_SIZE,
+    with: { account: true },
+  });
+
+  const { newerUrl, olderUrl } = paginationUrls(page, page * PAGE_SIZE < total);
+
+  return c.html(
+    <ReactionListPage
+      accountOwner={accountOwner}
+      post={post}
+      pageTitle="Shared by"
+      heading={
+        total === 1 ? "1 share" : `${numberFormatter.format(total)} shares`
+      }
+      baseUrl={c.req.url}
+      newerUrl={newerUrl}
+      olderUrl={olderUrl}
+    >
+      <PublicAccountList
+        accounts={rows.map((r) => r.account)}
+        baseUrl={c.req.url}
+      />
+    </ReactionListPage>,
+  );
+});
+
+postReactions.get("/reactions/:emoji", async (c) => {
+  const emoji = c.req.param("emoji");
+  if (emoji == null || emoji === "") return c.notFound();
+  const loaded = await loadLocalPost(c);
+  if (loaded == null) return c.notFound();
+  const { accountOwner, post } = loaded;
+  const page = parsePage(c);
+  if (page == null) return c.notFound();
+
+  const [{ total }] = await db
+    .select({ total: count() })
+    .from(reactions)
+    .where(and(eq(reactions.postId, post.id), eq(reactions.emoji, emoji)));
+  if (total < 1) return c.notFound();
+  const maxPage = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  if (page > maxPage) return c.notFound();
+
+  const rows = await db.query.reactions.findMany({
+    where: { postId: { eq: post.id }, emoji: { eq: emoji } },
+    orderBy: (reactions, { desc }) => [desc(reactions.created)],
+    limit: PAGE_SIZE,
+    offset: (page - 1) * PAGE_SIZE,
+    with: { account: true },
+  });
+
+  const { newerUrl, olderUrl } = paginationUrls(page, page * PAGE_SIZE < total);
+
+  return c.html(
+    <ReactionListPage
+      accountOwner={accountOwner}
+      post={post}
+      pageTitle={`Reacted ${emoji} by`}
+      heading={
+        total === 1
+          ? `1 reaction with ${emoji}`
+          : `${numberFormatter.format(total)} reactions with ${emoji}`
+      }
+      baseUrl={c.req.url}
+      newerUrl={newerUrl}
+      olderUrl={olderUrl}
+    >
+      <PublicAccountList
+        accounts={rows.map((r) => r.account)}
+        baseUrl={c.req.url}
+      />
+    </ReactionListPage>,
+  );
+});
+
+postReactions.get("/quotes", async (c) => {
+  const loaded = await loadLocalPost(c);
+  if (loaded == null) return c.notFound();
+  const { accountOwner, post } = loaded;
+  const page = parsePage(c);
+  if (page == null) return c.notFound();
+
+  const [{ total }] = await db
+    .select({ total: count() })
+    .from(posts)
+    .where(
+      and(
+        eq(posts.quoteTargetId, post.id),
+        or(eq(posts.quoteState, "accepted"), isNull(posts.quoteState)),
+        isNull(posts.sharingId),
+        or(eq(posts.visibility, "public"), eq(posts.visibility, "unlisted")),
+      ),
+    );
+  const maxPage = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  if (page > maxPage) return c.notFound();
+
+  const quoteRows = await db.query.posts.findMany({
+    where: {
+      RAW: (posts, { and, eq, isNull, or }) =>
+        and(
+          eq(posts.quoteTargetId, post.id),
+          or(eq(posts.quoteState, "accepted"), isNull(posts.quoteState)),
+          isNull(posts.sharingId),
+          or(eq(posts.visibility, "public"), eq(posts.visibility, "unlisted")),
+        )!,
+    },
+    orderBy: (posts, { desc }) => [desc(posts.id)],
+    limit: PAGE_SIZE,
+    offset: (page - 1) * PAGE_SIZE,
+    with: {
+      account: { with: { owner: true } },
+      media: true,
+      poll: { with: { options: true } },
+      sharing: {
+        with: {
+          account: { with: { owner: true } },
+          media: true,
+          poll: { with: { options: true } },
+          replyTarget: { with: { account: { with: { owner: true } } } },
+          quoteTarget: {
+            with: {
+              account: { with: { owner: true } },
+              media: true,
+              poll: { with: { options: true } },
+              replyTarget: {
+                with: { account: { with: { owner: true } } },
+              },
+              reactions: true,
+            },
+          },
+          reactions: true,
+        },
+      },
+      replyTarget: { with: { account: { with: { owner: true } } } },
+      quoteTarget: {
+        with: {
+          account: { with: { owner: true } },
+          media: true,
+          poll: { with: { options: true } },
+          replyTarget: { with: { account: { with: { owner: true } } } },
+          reactions: true,
+        },
+      },
+      reactions: true,
+    },
+  });
+
+  const { newerUrl, olderUrl } = paginationUrls(page, page * PAGE_SIZE < total);
+
+  return c.html(
+    <ReactionListPage
+      accountOwner={accountOwner}
+      post={post}
+      pageTitle="Quoted by"
+      heading={
+        total === 1 ? "1 quote" : `${numberFormatter.format(total)} quotes`
+      }
+      baseUrl={c.req.url}
+      newerUrl={newerUrl}
+      olderUrl={olderUrl}
+    >
+      <div class="mt-2 divide-y divide-neutral-200 dark:divide-neutral-800">
+        {quoteRows.map((q) => (
+          <PostView post={q} baseUrl={c.req.url} />
+        ))}
+      </div>
+    </ReactionListPage>,
+  );
+});
+
+interface ReactionListPageProps {
+  readonly accountOwner: AccountOwner;
+  readonly post: FeaturedPost;
+  readonly pageTitle: string;
+  readonly heading: string;
+  readonly baseUrl: URL | string;
+  readonly newerUrl?: string;
+  readonly olderUrl?: string;
+  readonly children?: unknown;
+}
+
+function ReactionListPage({
+  accountOwner,
+  post,
+  pageTitle,
+  heading,
+  baseUrl,
+  newerUrl,
+  olderUrl,
+  children,
+}: ReactionListPageProps) {
+  const summary =
+    post.summary ??
+    ((post.content ?? "").length > 30
+      ? `${(post.content ?? "").substring(0, 30)}…`
+      : (post.content ?? ""));
+  return (
+    <Layout
+      title={`${pageTitle}: ${summary} — ${post.account.name}`}
+      shortTitle={pageTitle}
+      description={post.summary ?? post.content}
+      imageUrl={post.account.avatarUrl}
+      themeColor={accountOwner.themeColor}
+    >
+      <main class="mx-auto w-full max-w-2xl px-4 py-8 sm:py-10">
+        <PostView post={post} featured={true} baseUrl={baseUrl} />
+        <section class="mt-8">
+          <h2 class="text-xs font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400">
+            {heading}
+          </h2>
+          {children}
+        </section>
+        {(newerUrl || olderUrl) && (
+          <nav class="mt-8 flex items-center justify-between gap-4">
+            <div>
+              {newerUrl && (
+                <a
+                  href={newerUrl}
+                  class="inline-flex items-center gap-1 text-sm text-neutral-600 hover:text-brand-700 dark:text-neutral-400 dark:hover:text-brand-400"
+                >
+                  <span class="i-lucide-arrow-left" aria-hidden="true" />
+                  Newer
+                </a>
+              )}
+            </div>
+            <div>
+              {olderUrl && (
+                <a
+                  href={olderUrl}
+                  class="inline-flex items-center gap-1 text-sm text-neutral-600 hover:text-brand-700 dark:text-neutral-400 dark:hover:text-brand-400"
+                >
+                  Older
+                  <span class="i-lucide-arrow-right" aria-hidden="true" />
+                </a>
+              )}
+            </div>
+          </nav>
+        )}
+      </main>
+    </Layout>
+  );
+}
+
+export default postReactions;

--- a/src/pages/profile/postReactions.tsx
+++ b/src/pages/profile/postReactions.tsx
@@ -318,7 +318,7 @@ function ReactionListPage({
     <Layout
       title={`${pageTitle}: ${summary} — ${post.account.name}`}
       shortTitle={pageTitle}
-      description={post.summary ?? post.content}
+      description={post.summary || post.content}
       imageUrl={post.account.avatarUrl}
       themeColor={accountOwner.themeColor}
     >

--- a/src/pages/profile/postRelations.ts
+++ b/src/pages/profile/postRelations.ts
@@ -1,0 +1,45 @@
+// Drizzle relational query `with` clause that hydrates a post with every
+// nested relation the Post component needs in order to render: the author's
+// account (and its owner row, used to detect local accounts and emit
+// permalink-based reaction list links), media, polls, reply targets, quote
+// targets, the sharing relation when the post is a boost, and the reactions
+// rendered in the post footer.
+//
+// Reuse this constant for every query whose results are passed to
+// PostView so the four SSR queries (profile feed, post permalink, hashtag
+// feed, and the reaction list pages) stay in sync when the post relation
+// graph changes.
+export const postViewRelations = {
+  account: { with: { owner: true } },
+  media: true,
+  poll: { with: { options: true } },
+  sharing: {
+    with: {
+      account: { with: { owner: true } },
+      media: true,
+      poll: { with: { options: true } },
+      replyTarget: { with: { account: { with: { owner: true } } } },
+      quoteTarget: {
+        with: {
+          account: { with: { owner: true } },
+          media: true,
+          poll: { with: { options: true } },
+          replyTarget: { with: { account: { with: { owner: true } } } },
+          reactions: true,
+        },
+      },
+      reactions: true,
+    },
+  },
+  replyTarget: { with: { account: { with: { owner: true } } } },
+  quoteTarget: {
+    with: {
+      account: { with: { owner: true } },
+      media: true,
+      poll: { with: { options: true } },
+      replyTarget: { with: { account: { with: { owner: true } } } },
+      reactions: true,
+    },
+  },
+  reactions: true,
+} as const;

--- a/src/pages/profile/profilePost.tsx
+++ b/src/pages/profile/profilePost.tsx
@@ -1,10 +1,9 @@
 import { Hono } from "hono";
 
 import { Layout } from "../../components/Layout.tsx";
-import { Post as PostView } from "../../components/Post.tsx";
+import { type PostAccount, Post as PostView } from "../../components/Post.tsx";
 import db from "../../db.ts";
 import {
-  type Account,
   type AccountOwner,
   type Medium,
   type Poll,
@@ -35,34 +34,36 @@ profilePost.get<"/:handle{@[^/]+}/:id{[-a-f0-9]+}">(async (c) => {
         )!,
     },
     with: {
-      account: true,
+      account: { with: { owner: true } },
       media: true,
       poll: { with: { options: true } },
       sharing: {
         with: {
-          account: true,
+          account: { with: { owner: true } },
           media: true,
           poll: { with: { options: true } },
-          replyTarget: { with: { account: true } },
+          replyTarget: { with: { account: { with: { owner: true } } } },
           quoteTarget: {
             with: {
-              account: true,
+              account: { with: { owner: true } },
               media: true,
               poll: { with: { options: true } },
-              replyTarget: { with: { account: true } },
+              replyTarget: {
+                with: { account: { with: { owner: true } } },
+              },
               reactions: true,
             },
           },
           reactions: true,
         },
       },
-      replyTarget: { with: { account: true } },
+      replyTarget: { with: { account: { with: { owner: true } } } },
       quoteTarget: {
         with: {
-          account: true,
+          account: { with: { owner: true } },
           media: true,
           poll: { with: { options: true } },
-          replyTarget: { with: { account: true } },
+          replyTarget: { with: { account: { with: { owner: true } } } },
           reactions: true,
         },
       },
@@ -71,34 +72,40 @@ profilePost.get<"/:handle{@[^/]+}/:id{[-a-f0-9]+}">(async (c) => {
         orderBy: (posts, { desc }) => [desc(posts.published)],
         limit: 20,
         with: {
-          account: true,
+          account: { with: { owner: true } },
           media: true,
           poll: { with: { options: true } },
           sharing: {
             with: {
-              account: true,
+              account: { with: { owner: true } },
               media: true,
               poll: { with: { options: true } },
-              replyTarget: { with: { account: true } },
+              replyTarget: {
+                with: { account: { with: { owner: true } } },
+              },
               quoteTarget: {
                 with: {
-                  account: true,
+                  account: { with: { owner: true } },
                   media: true,
                   poll: { with: { options: true } },
-                  replyTarget: { with: { account: true } },
+                  replyTarget: {
+                    with: { account: { with: { owner: true } } },
+                  },
                   reactions: true,
                 },
               },
               reactions: true,
             },
           },
-          replyTarget: { with: { account: true } },
+          replyTarget: { with: { account: { with: { owner: true } } } },
           quoteTarget: {
             with: {
-              account: true,
+              account: { with: { owner: true } },
               media: true,
               poll: { with: { options: true } },
-              replyTarget: { with: { account: true } },
+              replyTarget: {
+                with: { account: { with: { owner: true } } },
+              },
               reactions: true,
             },
           },
@@ -117,66 +124,66 @@ profilePost.get<"/:handle{@[^/]+}/:id{[-a-f0-9]+}">(async (c) => {
 interface PostPageProps {
   readonly accountOwner: AccountOwner;
   readonly post: Post & {
-    account: Account;
+    account: PostAccount;
     media: Medium[];
     poll: (Poll & { options: PollOption[] }) | null;
     sharing:
       | (Post & {
-          account: Account;
+          account: PostAccount;
           media: Medium[];
           poll: (Poll & { options: PollOption[] }) | null;
-          replyTarget: (Post & { account: Account }) | null;
+          replyTarget: (Post & { account: PostAccount }) | null;
           quoteTarget:
             | (Post & {
-                account: Account;
+                account: PostAccount;
                 media: Medium[];
                 poll: (Poll & { options: PollOption[] }) | null;
-                replyTarget: (Post & { account: Account }) | null;
+                replyTarget: (Post & { account: PostAccount }) | null;
                 reactions: Reaction[];
               })
             | null;
           reactions: Reaction[];
         })
       | null;
-    replyTarget: (Post & { account: Account }) | null;
+    replyTarget: (Post & { account: PostAccount }) | null;
     quoteTarget:
       | (Post & {
-          account: Account;
+          account: PostAccount;
           media: Medium[];
           poll: (Poll & { options: PollOption[] }) | null;
-          replyTarget: (Post & { account: Account }) | null;
+          replyTarget: (Post & { account: PostAccount }) | null;
           reactions: Reaction[];
         })
       | null;
     replies: (Post & {
-      account: Account;
+      account: PostAccount;
       media: Medium[];
       poll: (Poll & { options: PollOption[] }) | null;
       sharing:
         | (Post & {
-            account: Account;
+            account: PostAccount;
             media: Medium[];
             poll: (Poll & { options: PollOption[] }) | null;
-            replyTarget: (Post & { account: Account }) | null;
+            replyTarget: (Post & { account: PostAccount }) | null;
             quoteTarget:
               | (Post & {
-                  account: Account;
+                  account: PostAccount;
                   media: Medium[];
                   poll: (Poll & { options: PollOption[] }) | null;
-                  replyTarget: (Post & { account: Account }) | null;
+                  replyTarget: (Post & { account: PostAccount }) | null;
                   reactions: Reaction[];
                 })
               | null;
             reactions: Reaction[];
           })
         | null;
-      replyTarget: (Post & { account: Account }) | null;
+      replyTarget: (Post & { account: PostAccount }) | null;
       quoteTarget:
         | (Post & {
-            account: Account;
+            account: PostAccount;
             media: Medium[];
             poll: (Poll & { options: PollOption[] }) | null;
-            replyTarget: (Post & { account: Account }) | null;
+            replyTarget: (Post & { account: PostAccount }) | null;
             reactions: Reaction[];
           })
         | null;

--- a/src/pages/profile/profilePost.tsx
+++ b/src/pages/profile/profilePost.tsx
@@ -12,6 +12,7 @@ import {
   type Reaction,
 } from "../../schema.ts";
 import { isUuid } from "../../uuid.ts";
+import { summarizePostForTitle } from "./summary.ts";
 
 const profilePost = new Hono();
 
@@ -195,11 +196,7 @@ interface PostPageProps {
 }
 
 function PostPage({ post, accountOwner, baseUrl }: PostPageProps) {
-  const summary =
-    post.summary ??
-    ((post.content ?? "").length > 30
-      ? `${(post.content ?? "").substring(0, 30)}…`
-      : (post.content ?? ""));
+  const summary = summarizePostForTitle(post);
   return (
     <Layout
       title={`${summary} — ${post.account.name}`}

--- a/src/pages/profile/profilePost.tsx
+++ b/src/pages/profile/profilePost.tsx
@@ -130,7 +130,7 @@ function PostPage({ post, accountOwner, baseUrl }: PostPageProps) {
     <Layout
       title={`${summary} — ${post.account.name}`}
       shortTitle={summary}
-      description={post.summary ?? post.content}
+      description={post.summary || post.content}
       imageUrl={post.account.avatarUrl}
       url={post.url ?? post.iri}
       links={[

--- a/src/pages/profile/profilePost.tsx
+++ b/src/pages/profile/profilePost.tsx
@@ -12,6 +12,7 @@ import {
   type Reaction,
 } from "../../schema.ts";
 import { isUuid } from "../../uuid.ts";
+import { postViewRelations } from "./postRelations.ts";
 import { summarizePostForTitle } from "./summary.ts";
 
 const profilePost = new Hono();
@@ -35,85 +36,13 @@ profilePost.get<"/:handle{@[^/]+}/:id{[-a-f0-9]+}">(async (c) => {
         )!,
     },
     with: {
-      account: { with: { owner: true } },
-      media: true,
-      poll: { with: { options: true } },
-      sharing: {
-        with: {
-          account: { with: { owner: true } },
-          media: true,
-          poll: { with: { options: true } },
-          replyTarget: { with: { account: { with: { owner: true } } } },
-          quoteTarget: {
-            with: {
-              account: { with: { owner: true } },
-              media: true,
-              poll: { with: { options: true } },
-              replyTarget: {
-                with: { account: { with: { owner: true } } },
-              },
-              reactions: true,
-            },
-          },
-          reactions: true,
-        },
-      },
-      replyTarget: { with: { account: { with: { owner: true } } } },
-      quoteTarget: {
-        with: {
-          account: { with: { owner: true } },
-          media: true,
-          poll: { with: { options: true } },
-          replyTarget: { with: { account: { with: { owner: true } } } },
-          reactions: true,
-        },
-      },
+      ...postViewRelations,
       replies: {
         where: { visibility: { in: ["public", "unlisted"] } },
         orderBy: (posts, { desc }) => [desc(posts.published)],
         limit: 20,
-        with: {
-          account: { with: { owner: true } },
-          media: true,
-          poll: { with: { options: true } },
-          sharing: {
-            with: {
-              account: { with: { owner: true } },
-              media: true,
-              poll: { with: { options: true } },
-              replyTarget: {
-                with: { account: { with: { owner: true } } },
-              },
-              quoteTarget: {
-                with: {
-                  account: { with: { owner: true } },
-                  media: true,
-                  poll: { with: { options: true } },
-                  replyTarget: {
-                    with: { account: { with: { owner: true } } },
-                  },
-                  reactions: true,
-                },
-              },
-              reactions: true,
-            },
-          },
-          replyTarget: { with: { account: { with: { owner: true } } } },
-          quoteTarget: {
-            with: {
-              account: { with: { owner: true } },
-              media: true,
-              poll: { with: { options: true } },
-              replyTarget: {
-                with: { account: { with: { owner: true } } },
-              },
-              reactions: true,
-            },
-          },
-          reactions: true,
-        },
+        with: postViewRelations,
       },
-      reactions: true,
     },
   });
   if (post == null) return c.notFound();

--- a/src/pages/profile/profilePost.tsx
+++ b/src/pages/profile/profilePost.tsx
@@ -1,16 +1,9 @@
 import { Hono } from "hono";
 
 import { Layout } from "../../components/Layout.tsx";
-import { type PostAccount, Post as PostView } from "../../components/Post.tsx";
+import { type PostForView, Post as PostView } from "../../components/Post.tsx";
 import db from "../../db.ts";
-import {
-  type AccountOwner,
-  type Medium,
-  type Poll,
-  type PollOption,
-  type Post,
-  type Reaction,
-} from "../../schema.ts";
+import { type AccountOwner } from "../../schema.ts";
 import { isUuid } from "../../uuid.ts";
 import { postViewRelations } from "./postRelations.ts";
 import { summarizePostForTitle } from "./summary.ts";
@@ -53,74 +46,7 @@ profilePost.get<"/:handle{@[^/]+}/:id{[-a-f0-9]+}">(async (c) => {
 
 interface PostPageProps {
   readonly accountOwner: AccountOwner;
-  readonly post: Post & {
-    account: PostAccount;
-    media: Medium[];
-    poll: (Poll & { options: PollOption[] }) | null;
-    sharing:
-      | (Post & {
-          account: PostAccount;
-          media: Medium[];
-          poll: (Poll & { options: PollOption[] }) | null;
-          replyTarget: (Post & { account: PostAccount }) | null;
-          quoteTarget:
-            | (Post & {
-                account: PostAccount;
-                media: Medium[];
-                poll: (Poll & { options: PollOption[] }) | null;
-                replyTarget: (Post & { account: PostAccount }) | null;
-                reactions: Reaction[];
-              })
-            | null;
-          reactions: Reaction[];
-        })
-      | null;
-    replyTarget: (Post & { account: PostAccount }) | null;
-    quoteTarget:
-      | (Post & {
-          account: PostAccount;
-          media: Medium[];
-          poll: (Poll & { options: PollOption[] }) | null;
-          replyTarget: (Post & { account: PostAccount }) | null;
-          reactions: Reaction[];
-        })
-      | null;
-    replies: (Post & {
-      account: PostAccount;
-      media: Medium[];
-      poll: (Poll & { options: PollOption[] }) | null;
-      sharing:
-        | (Post & {
-            account: PostAccount;
-            media: Medium[];
-            poll: (Poll & { options: PollOption[] }) | null;
-            replyTarget: (Post & { account: PostAccount }) | null;
-            quoteTarget:
-              | (Post & {
-                  account: PostAccount;
-                  media: Medium[];
-                  poll: (Poll & { options: PollOption[] }) | null;
-                  replyTarget: (Post & { account: PostAccount }) | null;
-                  reactions: Reaction[];
-                })
-              | null;
-            reactions: Reaction[];
-          })
-        | null;
-      replyTarget: (Post & { account: PostAccount }) | null;
-      quoteTarget:
-        | (Post & {
-            account: PostAccount;
-            media: Medium[];
-            poll: (Poll & { options: PollOption[] }) | null;
-            replyTarget: (Post & { account: PostAccount }) | null;
-            reactions: Reaction[];
-          })
-        | null;
-      reactions: Reaction[];
-    })[];
-    reactions: Reaction[];
-  };
+  readonly post: PostForView & { replies: PostForView[] };
   readonly baseUrl: URL | string;
 }
 

--- a/src/pages/profile/summary.ts
+++ b/src/pages/profile/summary.ts
@@ -1,0 +1,14 @@
+import type { Post } from "../../schema.ts";
+
+const SUMMARY_MAX_LENGTH = 30;
+
+export function summarizePostForTitle(
+  post: Pick<Post, "summary" | "content">,
+): string {
+  if (post.summary != null) return post.summary;
+  const content = post.content ?? "";
+  if (content.length > SUMMARY_MAX_LENGTH) {
+    return `${content.substring(0, SUMMARY_MAX_LENGTH)}…`;
+  }
+  return content;
+}

--- a/src/pages/profile/summary.ts
+++ b/src/pages/profile/summary.ts
@@ -5,7 +5,7 @@ const SUMMARY_MAX_LENGTH = 30;
 export function summarizePostForTitle(
   post: Pick<Post, "summary" | "content">,
 ): string {
-  if (post.summary != null) return post.summary;
+  if (post.summary) return post.summary;
   const content = post.content ?? "";
   if (content.length > SUMMARY_MAX_LENGTH) {
     return `${content.substring(0, SUMMARY_MAX_LENGTH)}…`;

--- a/src/pages/tags/index.tsx
+++ b/src/pages/tags/index.tsx
@@ -1,10 +1,9 @@
 import { Hono } from "hono";
 
 import { Layout } from "../../components/Layout.tsx";
-import { Post as PostView } from "../../components/Post.tsx";
+import { type PostAccount, Post as PostView } from "../../components/Post.tsx";
 import { db } from "../../db.ts";
 import {
-  type Account,
   accountOwners,
   type Medium,
   type Poll,
@@ -38,34 +37,34 @@ tags.get(async (c) => {
     },
     orderBy: (posts, { desc }) => [desc(posts.id)],
     with: {
-      account: true,
+      account: { with: { owner: true } },
       media: true,
       poll: { with: { options: true } },
       sharing: {
         with: {
-          account: true,
+          account: { with: { owner: true } },
           media: true,
           poll: { with: { options: true } },
-          replyTarget: { with: { account: true } },
+          replyTarget: { with: { account: { with: { owner: true } } } },
           quoteTarget: {
             with: {
-              account: true,
+              account: { with: { owner: true } },
               media: true,
               poll: { with: { options: true } },
-              replyTarget: { with: { account: true } },
+              replyTarget: { with: { account: { with: { owner: true } } } },
               reactions: true,
             },
           },
           reactions: true,
         },
       },
-      replyTarget: { with: { account: true } },
+      replyTarget: { with: { account: { with: { owner: true } } } },
       quoteTarget: {
         with: {
-          account: true,
+          account: { with: { owner: true } },
           media: true,
           poll: { with: { options: true } },
-          replyTarget: { with: { account: true } },
+          replyTarget: { with: { account: { with: { owner: true } } } },
           reactions: true,
         },
       },
@@ -78,34 +77,34 @@ tags.get(async (c) => {
 interface TagPageProps {
   readonly tag: string;
   readonly posts: (Post & {
-    account: Account;
+    account: PostAccount;
     media: Medium[];
     poll: (Poll & { options: PollOption[] }) | null;
     sharing:
       | (Post & {
-          account: Account;
+          account: PostAccount;
           media: Medium[];
           poll: (Poll & { options: PollOption[] }) | null;
-          replyTarget: (Post & { account: Account }) | null;
+          replyTarget: (Post & { account: PostAccount }) | null;
           quoteTarget:
             | (Post & {
-                account: Account;
+                account: PostAccount;
                 media: Medium[];
                 poll: (Poll & { options: PollOption[] }) | null;
-                replyTarget: (Post & { account: Account }) | null;
+                replyTarget: (Post & { account: PostAccount }) | null;
                 reactions: Reaction[];
               })
             | null;
           reactions: Reaction[];
         })
       | null;
-    replyTarget: (Post & { account: Account }) | null;
+    replyTarget: (Post & { account: PostAccount }) | null;
     quoteTarget:
       | (Post & {
-          account: Account;
+          account: PostAccount;
           media: Medium[];
           poll: (Poll & { options: PollOption[] }) | null;
-          replyTarget: (Post & { account: Account }) | null;
+          replyTarget: (Post & { account: PostAccount }) | null;
           reactions: Reaction[];
         })
       | null;

--- a/src/pages/tags/index.tsx
+++ b/src/pages/tags/index.tsx
@@ -1,16 +1,9 @@
 import { Hono } from "hono";
 
 import { Layout } from "../../components/Layout.tsx";
-import { type PostAccount, Post as PostView } from "../../components/Post.tsx";
+import { type PostForView, Post as PostView } from "../../components/Post.tsx";
 import { db } from "../../db.ts";
-import {
-  accountOwners,
-  type Medium,
-  type Poll,
-  type PollOption,
-  type Post,
-  type Reaction,
-} from "../../schema.ts";
+import { accountOwners } from "../../schema.ts";
 import { postViewRelations } from "../profile/postRelations.ts";
 
 const tags = new Hono().basePath("/:tag");
@@ -44,40 +37,7 @@ tags.get(async (c) => {
 
 interface TagPageProps {
   readonly tag: string;
-  readonly posts: (Post & {
-    account: PostAccount;
-    media: Medium[];
-    poll: (Poll & { options: PollOption[] }) | null;
-    sharing:
-      | (Post & {
-          account: PostAccount;
-          media: Medium[];
-          poll: (Poll & { options: PollOption[] }) | null;
-          replyTarget: (Post & { account: PostAccount }) | null;
-          quoteTarget:
-            | (Post & {
-                account: PostAccount;
-                media: Medium[];
-                poll: (Poll & { options: PollOption[] }) | null;
-                replyTarget: (Post & { account: PostAccount }) | null;
-                reactions: Reaction[];
-              })
-            | null;
-          reactions: Reaction[];
-        })
-      | null;
-    replyTarget: (Post & { account: PostAccount }) | null;
-    quoteTarget:
-      | (Post & {
-          account: PostAccount;
-          media: Medium[];
-          poll: (Poll & { options: PollOption[] }) | null;
-          replyTarget: (Post & { account: PostAccount }) | null;
-          reactions: Reaction[];
-        })
-      | null;
-    reactions: Reaction[];
-  })[];
+  readonly posts: PostForView[];
   readonly baseUrl: URL | string;
 }
 

--- a/src/pages/tags/index.tsx
+++ b/src/pages/tags/index.tsx
@@ -11,6 +11,7 @@ import {
   type Post,
   type Reaction,
 } from "../../schema.ts";
+import { postViewRelations } from "../profile/postRelations.ts";
 
 const tags = new Hono().basePath("/:tag");
 
@@ -36,40 +37,7 @@ tags.get(async (c) => {
         )!,
     },
     orderBy: (posts, { desc }) => [desc(posts.id)],
-    with: {
-      account: { with: { owner: true } },
-      media: true,
-      poll: { with: { options: true } },
-      sharing: {
-        with: {
-          account: { with: { owner: true } },
-          media: true,
-          poll: { with: { options: true } },
-          replyTarget: { with: { account: { with: { owner: true } } } },
-          quoteTarget: {
-            with: {
-              account: { with: { owner: true } },
-              media: true,
-              poll: { with: { options: true } },
-              replyTarget: { with: { account: { with: { owner: true } } } },
-              reactions: true,
-            },
-          },
-          reactions: true,
-        },
-      },
-      replyTarget: { with: { account: { with: { owner: true } } } },
-      quoteTarget: {
-        with: {
-          account: { with: { owner: true } },
-          media: true,
-          poll: { with: { options: true } },
-          replyTarget: { with: { account: { with: { owner: true } } } },
-          reactions: true,
-        },
-      },
-      reactions: true,
-    },
+    with: postViewRelations,
   });
   return c.html(<TagPage tag={tag} posts={postList} baseUrl={c.req.url} />);
 });


### PR DESCRIPTION
Summary
-------

Hollo's public post permalink page already shows the post and its replies, but there's no way to see who liked, boosted, reacted with a particular emoji, or quoted it. This PR adds four server-rendered pages under each local post permalink:

 -  `/@:handle/:id/likes`: accounts that liked the post
 -  `/@:handle/:id/shares`: accounts that boosted it
 -  `/@:handle/:id/reactions/:emoji`: accounts that reacted with the given emoji
 -  `/@:handle/:id/quotes`: posts that quote it

Each page renders the original post above the list, with `?page=N` pagination at 100 entries per page. On the profile feed and post permalink page, the per-post like, share, quote, and reaction-emoji indicators are now clickable links into these pages for local posts; remote posts continue to render the counts as plain text.

The `/shares` and `/quotes` lists filter to `visibility ∈ {public, unlisted}` so private boosts and accepted private quotes aren't exposed in the public HTML. That's stricter than the pre-existing `/api/v1/statuses/:id/reblogged_by` endpoint, which returns all shares regardless of visibility. The post-footer counter on the source post still shows the persisted `sharesCount`/`quotesCount`, matching Mastodon's API convention; the destination heading and the listing both apply the same visibility filter, so the heading number reflects only what's actually visible.

Implementation notes
--------------------

The four routes live in *src/pages/profile/postReactions.tsx*, mounted alongside *src/pages/profile/profilePost.tsx* under the same `/:handle/:id` prefix. The new *src/components/PublicAccountList.tsx* renders the likes/shares/reactions rows; the `/quotes` page reuses the existing `Post` component with the same divider styling as the permalink page's reply list.

*src/components/Post.tsx* gained a `localPermalink` computation that switches on `post.account.owner != null`. When the relation is loaded, the count indicators and reaction emojis become links into the new pages; otherwise the existing plain-text rendering is preserved. To decide whether the footer indicators should link, the profile and tag queries now load `account.owner` anywhere a post can render its footer: top-level posts, shared posts, quote targets, and replies (*src/pages/profile/profilePost.tsx*, *src/pages/profile/index.tsx*, *src/pages/tags/index.tsx*).

Custom emoji reactions render the image inline in the destination page heading by looking up one of the loaded rows' `customEmoji` URL and passing it through `proxyUrl`. Plain Unicode emojis fall back to the text character.

Test plan
---------

 -  [ ] On a local profile feed, verify likes/shares/quotes counts and reaction emojis on a post are now clickable.
 -  [ ] Visit `/likes`, `/shares`, `/quotes`, and a `/reactions/:emoji` page (both Unicode and custom emoji). Confirm the featured post renders at the top and the list below.
 -  [ ] Confirm a boosted remote post (rendered via the local profile) keeps its counts as plain text with no link wrappers.
 -  [ ] Hit `/@:handle/:id/reactions/<emoji-nobody-used>` and `/@:handle/:id/likes?page=999`. Both requests should return `404 Not Found`.
 -  [ ] Boost or quote a local post with `visibility=private` and confirm it does not appear on the `/shares` or `/quotes` page.
 -  [ ] `mise run check` passes.