### PR TITLE
docs: update Railway one-click deploy template URL

### DIFF
--- a/docs/src/content/docs/install/railway.mdx
+++ b/docs/src/content/docs/install/railway.mdx
@@ -38,7 +38,7 @@ so you'll need to use a client app like [Phanpy] for now.
 
 [Railway]: https://railway.app/
 [Deploy on Railway]: https://railway.app/button.svg
-[Railway template]: https://railway.app/template/eopPyH?referralCode=qeEK5G
+[Railway template]: https://railway.com/deploy/eopPyH?referralCode=qeEK5G
 [Phanpy]: https://phanpy.social/
 
 

--- a/docs/src/content/docs/ja/install/railway.mdx
+++ b/docs/src/content/docs/ja/install/railway.mdx
@@ -36,7 +36,7 @@ https://yourdomain/setup
 
 [Railway]: https://railway.app/
 [Deploy on Railway]: https://railway.app/button.svg
-[Railway template]: https://railway.app/template/eopPyH?referralCode=qeEK5G
+[Railway template]: https://railway.com/deploy/eopPyH?referralCode=qeEK5G
 [Phanpy]: https://phanpy.social/
 
 

--- a/docs/src/content/docs/ko/install/railway.mdx
+++ b/docs/src/content/docs/ko/install/railway.mdx
@@ -36,7 +36,7 @@ https://yourdomain/setup (yourdomain은 여러분의 도메인으로 치환)
 
 [Railway]: https://railway.app/
 [Deploy on Railway]: https://railway.app/button.svg
-[Railway template]: https://railway.app/template/eopPyH?referralCode=qeEK5G
+[Railway template]: https://railway.com/deploy/eopPyH?referralCode=qeEK5G
 [Phanpy]: https://phanpy.social/
 
 

--- a/docs/src/content/docs/zh-cn/install/railway.mdx
+++ b/docs/src/content/docs/zh-cn/install/railway.mdx
@@ -23,7 +23,7 @@ import { Aside } from "@astrojs/starlight/components";
 
 [Railway]: https://railway.app/
 [在 Railway 上部署]: https://railway.app/button.svg
-[Railway 模板]: https://railway.app/template/eopPyH?referralCode=qeEK5G
+[Railway 模板]: https://railway.com/deploy/eopPyH?referralCode=qeEK5G
 [Phanpy]: https://phanpy.social/
 
 

--- a/docs/src/content/docs/zh-tw/install/railway.mdx
+++ b/docs/src/content/docs/zh-tw/install/railway.mdx
@@ -23,7 +23,7 @@ import { Aside } from "@astrojs/starlight/components";
 
 [Railway]: https://railway.app/
 [在 Railway 上部署]: https://railway.app/button.svg
-[Railway 模板]: https://railway.app/template/eopPyH?referralCode=qeEK5G
+[Railway 模板]: https://railway.com/deploy/eopPyH?referralCode=qeEK5G
 [Phanpy]: https://phanpy.social/
 
 


### PR DESCRIPTION
## Summary

Updates the stale Railway one-click deploy template URL in the install/railway docs page across all five translations (en, ja, ko, zh-cn, zh-tw).

The `[Railway template]` reference link target changes from the old scheme `https://railway.app/template/eopPyH?referralCode=qeEK5G` to the current permalink `https://railway.com/deploy/eopPyH?referralCode=qeEK5G`. The `?referralCode=qeEK5G` referral attribution is preserved.

## Why this matters

Issue #395 reports that the Railway deploy template linked from the docs is dead. The maintainer confirmed in the thread that Railway changed its template permalink scheme: the old `railway.app/template/<id>` URLs no longer resolve, and the working permalink is now `https://railway.com/deploy/eopPyH`. New users following the docs hit a broken one-click deploy link.

## Testing

N/A (documentation-only). No application code or behavior changes. The reference-link block and frontmatter are otherwise untouched; only the URL path was updated. A `grep -r "railway.app/template" docs/` after the change returns no matches.

Fixes #395
